### PR TITLE
Upgrade to brighterscript@0.39.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -381,11 +381,11 @@
             }
         },
         "@xml-tools/parser": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/@xml-tools/parser/-/parser-1.0.9.tgz",
-            "integrity": "sha512-TB/EwgsJh9165k1NTapYyPIhgz4DEUnvmQhkj6Fvyfqc/0p9nFMg2kHuKroWg6Tjwr8y2gvi9wWVXerfXtrQ1w==",
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/@xml-tools/parser/-/parser-1.0.10.tgz",
+            "integrity": "sha512-9oRb68wEKT+MRB7e2GwTiKicRKVXKzquBDGgH6YcGafvnSYXorWi2oaTVtbv2109RlGiQSnoXaQFUXCnHwFS7Q==",
             "requires": {
-                "chevrotain": "7.1.0"
+                "chevrotain": "7.1.1"
             }
         },
         "acorn": {
@@ -627,9 +627,9 @@
             "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
         },
         "bl": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-            "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
             "requires": {
                 "buffer": "^5.5.0",
                 "inherits": "^2.0.4",
@@ -654,12 +654,13 @@
             }
         },
         "brighterscript": {
-            "version": "0.29.0",
-            "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.29.0.tgz",
-            "integrity": "sha512-1KxTbIEZbAGrDduR5wBBkmUkdUZhDpS1pqHUgDttK6qTNTjEXkzZVuLDawKXrDV7GC5s5/HbWZohpsJuGSxeNw==",
+            "version": "0.33.0",
+            "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.33.0.tgz",
+            "integrity": "sha512-f7tcneebDxRpIzRqxZDMQHQII+FaL4SBtdmUAsp+419ThqFRPAeJZM0vTIVyAQF9wi8WRDfGug5IrygUwAnJMg==",
             "requires": {
                 "@xml-tools/parser": "^1.0.7",
                 "array-flat-polyfill": "^1.0.1",
+                "bslib": "npm:@rokucommunity/bslib@^0.1.1",
                 "chalk": "^2.4.2",
                 "chokidar": "^3.0.2",
                 "clear": "^0.1.0",
@@ -782,9 +783,9 @@
                     "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
                 },
                 "string-width": {
-                    "version": "4.2.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-                    "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.1.tgz",
+                    "integrity": "sha512-LL0OLyN6AnfV9xqGQpDBwedT2Rt63737LxvsRxbcwpa2aIeynBApG2Sm//F3TaLHIR1aJBN52DWklc06b94o5Q==",
                     "requires": {
                         "emoji-regex": "^8.0.0",
                         "is-fullwidth-code-point": "^3.0.0",
@@ -848,6 +849,11 @@
             "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
             "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true
+        },
+        "bslib": {
+            "version": "npm:@rokucommunity/bslib@0.1.1",
+            "resolved": "https://registry.npmjs.org/@rokucommunity/bslib/-/bslib-0.1.1.tgz",
+            "integrity": "sha512-2ox6EUL+UTtccTbD4dbVjZK3QHa0PHCqpoKMF8lZz9ayzzEP3iVPF8KZR6hOi6bxsIcbGXVjqmtCVkpC4P9SrA=="
         },
         "buffer": {
             "version": "5.7.1",
@@ -934,9 +940,9 @@
             "dev": true
         },
         "chevrotain": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-7.1.0.tgz",
-            "integrity": "sha512-msTqYIGb+8z4UpNxliBlowlfFJtBQjTSdnOWgMD/llcE5cQHDbFMjHGdCMJSsPG/Op89c6/ERCmYku4UHDhHVA==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-7.1.1.tgz",
+            "integrity": "sha512-wy3mC1x4ye+O+QkEinVJkPf5u2vsrDIYW9G7ZuwFl6v/Yu0LwUuT2POsb+NUWApebyxfkQq6+yDfRExbnI5rcw==",
             "requires": {
                 "regexp-to-ast": "0.5.0"
             }
@@ -2485,9 +2491,9 @@
             }
         },
         "luxon": {
-            "version": "1.25.0",
-            "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.25.0.tgz",
-            "integrity": "sha512-hEgLurSH8kQRjY6i4YLey+mcKVAWXbDNlZRmM6AgWDJ1cY3atl8Ztf5wEY7VBReFbmGnwQPz7KYJblL8B2k0jQ=="
+            "version": "1.26.0",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.26.0.tgz",
+            "integrity": "sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A=="
         },
         "make-dir": {
             "version": "2.1.0",
@@ -3278,9 +3284,9 @@
             }
         },
         "roku-deploy": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.2.4.tgz",
-            "integrity": "sha512-teZB4sRWS2EVHx8KWSqHW4QS9B2Z5jD5MrZrbdikl3thMljdVkbGLkarxrFw1NZfMR6nf0b0XXygOWjvePIeuw==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.3.0.tgz",
+            "integrity": "sha512-85XAgFH7AZylxIiECHbfydNEYeUUEEs/iq/zl3G3gqgM+x3fT/JnnkqrwgdFdLBj+aJVR3ZlyhuUWjDh1WxMbw==",
             "requires": {
                 "archiver": "^3.0.0",
                 "dateformat": "^3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -386,9 +386,9 @@
             }
         },
         "@xml-tools/parser": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/@xml-tools/parser/-/parser-1.0.10.tgz",
-            "integrity": "sha512-9oRb68wEKT+MRB7e2GwTiKicRKVXKzquBDGgH6YcGafvnSYXorWi2oaTVtbv2109RlGiQSnoXaQFUXCnHwFS7Q==",
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@xml-tools/parser/-/parser-1.0.11.tgz",
+            "integrity": "sha512-aKqQ077XnR+oQtHJlrAflaZaL7qZsulWc/i/ZEooar5JiWj1eLt0+Wg28cpa+XLney107wXqneC+oG1IZvxkTA==",
             "requires": {
                 "chevrotain": "7.1.1"
             },
@@ -467,6 +467,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
             "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+            "dev": true,
             "requires": {
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
@@ -479,63 +480,6 @@
             "dev": true,
             "requires": {
                 "default-require-extensions": "^2.0.0"
-            }
-        },
-        "archiver": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/archiver/-/archiver-3.1.1.tgz",
-            "integrity": "sha512-5Hxxcig7gw5Jod/8Gq0OneVgLYET+oNHcxgWItq4TbhOzRLKNAFUb9edAftiMKXvXfCB0vbGrJdZDNq0dWMsxg==",
-            "requires": {
-                "archiver-utils": "^2.1.0",
-                "async": "^2.6.3",
-                "buffer-crc32": "^0.2.1",
-                "glob": "^7.1.4",
-                "readable-stream": "^3.4.0",
-                "tar-stream": "^2.1.0",
-                "zip-stream": "^2.1.2"
-            }
-        },
-        "archiver-utils": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
-            "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
-            "requires": {
-                "glob": "^7.1.4",
-                "graceful-fs": "^4.2.0",
-                "lazystream": "^1.0.0",
-                "lodash.defaults": "^4.2.0",
-                "lodash.difference": "^4.5.0",
-                "lodash.flatten": "^4.4.0",
-                "lodash.isplainobject": "^4.0.6",
-                "lodash.union": "^4.6.0",
-                "normalize-path": "^3.0.0",
-                "readable-stream": "^2.0.0"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-                },
-                "readable-stream": {
-                    "version": "2.3.7",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "safe-buffer": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-                }
             }
         },
         "archy": {
@@ -589,14 +533,6 @@
             "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
             "dev": true
         },
-        "async": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-            "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-            "requires": {
-                "lodash": "^4.17.14"
-            }
-        },
         "asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -623,11 +559,6 @@
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
-        "base64-js": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-        },
         "bcrypt-pbkdf": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -640,16 +571,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
             "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
-        },
-        "bl": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-            "requires": {
-                "buffer": "^5.5.0",
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
-            }
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -669,16 +590,16 @@
             }
         },
         "brighterscript": {
-            "version": "0.37.3",
-            "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.37.3.tgz",
-            "integrity": "sha512-B/Op00MePl79wOc9b9W6o0tJTcHhwvA7mgz8ocx8n94+GWZJ+tISB+YtDSVLuagM4UcHCECtDqZJER0gRQBVEA==",
+            "version": "0.39.3",
+            "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.39.3.tgz",
+            "integrity": "sha512-wKF9Nyv78puQf8j0dFe3RMv2+PiHf4CLkxwhM6QrozcXJYtOe5vxx6EuFSjY6bz3dri15yiykxCmHKsJ7K63Tg==",
             "requires": {
                 "@rokucommunity/bslib": "^0.1.1",
                 "@xml-tools/parser": "^1.0.7",
                 "array-flat-polyfill": "^1.0.1",
                 "chalk": "^2.4.2",
                 "chevrotain": "^7.0.1",
-                "chokidar": "^3.0.2",
+                "chokidar": "^3.5.1",
                 "clear": "^0.1.0",
                 "cross-platform-clear-console": "^2.3.0",
                 "debounce-promise": "^3.1.0",
@@ -693,11 +614,11 @@
                 "moment": "^2.23.0",
                 "p-settle": "^2.1.0",
                 "parse-ms": "^2.1.0",
-                "roku-deploy": "^3.2.4",
+                "roku-deploy": "^3.4.1",
                 "serialize-error": "^7.0.1",
                 "source-map": "^0.7.3",
-                "vscode-languageserver": "^6.1.1",
-                "vscode-languageserver-protocol": "~3.15.3",
+                "vscode-languageserver": "7.0.0",
+                "vscode-languageserver-protocol": "3.16.0",
                 "vscode-languageserver-textdocument": "^1.0.1",
                 "vscode-uri": "^2.1.1",
                 "xml2js": "^0.4.19",
@@ -715,6 +636,30 @@
                     "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
                     "requires": {
                         "color-convert": "^2.0.1"
+                    }
+                },
+                "anymatch": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+                    "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+                    "requires": {
+                        "normalize-path": "^3.0.0",
+                        "picomatch": "^2.0.4"
+                    }
+                },
+                "chokidar": {
+                    "version": "3.5.2",
+                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+                    "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+                    "requires": {
+                        "anymatch": "~3.1.2",
+                        "braces": "~3.0.2",
+                        "fsevents": "~2.3.2",
+                        "glob-parent": "~5.1.2",
+                        "is-binary-path": "~2.1.0",
+                        "is-glob": "~4.0.1",
+                        "normalize-path": "~3.0.0",
+                        "readdirp": "~3.6.0"
                     }
                 },
                 "cliui": {
@@ -755,6 +700,12 @@
                         "universalify": "^0.1.0"
                     }
                 },
+                "fsevents": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+                    "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+                    "optional": true
+                },
                 "is-fullwidth-code-point": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -766,6 +717,14 @@
                     "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
                     "requires": {
                         "graceful-fs": "^4.1.6"
+                    }
+                },
+                "readdirp": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+                    "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+                    "requires": {
+                        "picomatch": "^2.2.1"
                     }
                 },
                 "string-width": {
@@ -821,9 +780,9 @@
                     }
                 },
                 "yargs-parser": {
-                    "version": "20.2.7",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
-                    "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw=="
+                    "version": "20.2.9",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+                    "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
                 }
             }
         },
@@ -832,20 +791,6 @@
             "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
             "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true
-        },
-        "buffer": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "requires": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.1.13"
-            }
-        },
-        "buffer-crc32": {
-            "version": "0.2.13",
-            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
         },
         "buffer-from": {
             "version": "1.1.1",
@@ -940,6 +885,7 @@
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
             "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+            "dev": true,
             "requires": {
                 "anymatch": "~3.1.1",
                 "braces": "~3.0.2",
@@ -1009,43 +955,6 @@
             "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
             "dev": true
         },
-        "compress-commons": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.1.tgz",
-            "integrity": "sha512-eVw6n7CnEMFzc3duyFVrQEuY1BlHR3rYsSztyG32ibGMW722i3C6IizEGMFmfMU+A+fALvBIwxN3czffTcdA+Q==",
-            "requires": {
-                "buffer-crc32": "^0.2.13",
-                "crc32-stream": "^3.0.1",
-                "normalize-path": "^3.0.0",
-                "readable-stream": "^2.3.6"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-                },
-                "readable-stream": {
-                    "version": "2.3.7",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "safe-buffer": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-                }
-            }
-        },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1098,23 +1007,6 @@
                 "nested-error-stacks": "^2.0.0",
                 "pify": "^4.0.1",
                 "safe-buffer": "^5.0.1"
-            }
-        },
-        "crc": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
-            "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
-            "requires": {
-                "buffer": "^5.1.0"
-            }
-        },
-        "crc32-stream": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-3.0.1.tgz",
-            "integrity": "sha512-mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==",
-            "requires": {
-                "crc": "^3.4.4",
-                "readable-stream": "^3.4.0"
             }
         },
         "cross-platform-clear-console": {
@@ -1240,14 +1132,6 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
             "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
             "dev": true
-        },
-        "end-of-stream": {
-            "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-            "requires": {
-                "once": "^1.4.0"
-            }
         },
         "error-ex": {
             "version": "1.3.2",
@@ -1675,11 +1559,6 @@
                 "mime-types": "^2.1.12"
             }
         },
-        "fs-constants": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
-        },
         "fs-extra": {
             "version": "9.0.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
@@ -1701,6 +1580,7 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
             "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+            "dev": true,
             "optional": true
         },
         "function-bind": {
@@ -1870,16 +1750,16 @@
                 "safer-buffer": ">= 2.1.2 < 3"
             }
         },
-        "ieee754": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-        },
         "ignore": {
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
             "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
             "dev": true
+        },
+        "immediate": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+            "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
         },
         "import-fresh": {
             "version": "3.2.1",
@@ -2315,45 +2195,22 @@
                 "verror": "1.10.0"
             }
         },
+        "jszip": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
+            "integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
+            "requires": {
+                "lie": "~3.3.0",
+                "pako": "~1.0.2",
+                "readable-stream": "~2.3.6",
+                "set-immediate-shim": "~1.0.1"
+            }
+        },
         "just-extend": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
             "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
             "dev": true
-        },
-        "lazystream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
-            "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
-            "requires": {
-                "readable-stream": "^2.0.5"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-                },
-                "readable-stream": {
-                    "version": "2.3.7",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "safe-buffer": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-                }
-            }
         },
         "lcov-parse": {
             "version": "0.0.10",
@@ -2369,6 +2226,14 @@
             "requires": {
                 "prelude-ls": "~1.1.2",
                 "type-check": "~0.3.2"
+            }
+        },
+        "lie": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+            "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+            "requires": {
+                "immediate": "~3.0.5"
             }
         },
         "load-json-file": {
@@ -2404,22 +2269,8 @@
         "lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
-        "lodash.defaults": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-            "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
-        },
-        "lodash.difference": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-            "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
-        },
-        "lodash.flatten": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-            "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "dev": true
         },
         "lodash.flattendeep": {
             "version": "4.4.0",
@@ -2432,16 +2283,6 @@
             "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
             "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
             "dev": true
-        },
-        "lodash.isplainobject": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-            "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-        },
-        "lodash.union": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-            "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
         },
         "log-driver": {
             "version": "1.2.7",
@@ -2474,9 +2315,9 @@
             }
         },
         "luxon": {
-            "version": "1.26.0",
-            "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.26.0.tgz",
-            "integrity": "sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A=="
+            "version": "1.27.0",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.27.0.tgz",
+            "integrity": "sha512-VKsFsPggTA0DvnxtJdiExAucKdAnwbCCNlMM5ENvHlxubqWd0xhZcdb4XgZ7QFNhaRhilXCFxHuoObP5BNA4PA=="
         },
         "make-dir": {
             "version": "2.1.0",
@@ -2958,6 +2799,11 @@
                 "release-zalgo": "^1.0.0"
             }
         },
+        "pako": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+        },
         "parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3142,19 +2988,36 @@
             }
         },
         "readable-stream": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
             "requires": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                }
             }
         },
         "readdirp": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
             "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+            "dev": true,
             "requires": {
                 "picomatch": "^2.0.4"
             }
@@ -3267,16 +3130,20 @@
             }
         },
         "roku-deploy": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.3.0.tgz",
-            "integrity": "sha512-85XAgFH7AZylxIiECHbfydNEYeUUEEs/iq/zl3G3gqgM+x3fT/JnnkqrwgdFdLBj+aJVR3ZlyhuUWjDh1WxMbw==",
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.4.1.tgz",
+            "integrity": "sha512-KomV/FvWv84f2Lh9V5c9stXCkGbM/L7B5cCLpNddBTlgh3zxyCAjEj2oFPYnzjbG+aNMvOpKatQ7Xx8bMJM03g==",
             "requires": {
-                "archiver": "^3.0.0",
+                "chalk": "^2.4.2",
                 "dateformat": "^3.0.3",
+                "eventemitter3": "^4.0.7",
                 "fs-extra": "^7.0.1",
                 "glob": "^7.1.6",
                 "jsonc-parser": "^2.3.0",
+                "jszip": "^3.6.0",
                 "minimatch": "^3.0.4",
+                "moment": "^2.29.1",
+                "parse-ms": "^2.1.0",
                 "path": "^0.12.7",
                 "request": "^2.88.0",
                 "xml2js": "^0.4.23"
@@ -3365,6 +3232,11 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
             "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+        },
+        "set-immediate-shim": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+            "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
         },
         "shebang-command": {
             "version": "1.2.0",
@@ -3634,18 +3506,6 @@
                 "lodash": "^4.17.14",
                 "slice-ansi": "^2.1.0",
                 "string-width": "^3.0.0"
-            }
-        },
-        "tar-stream": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-            "requires": {
-                "bl": "^4.0.3",
-                "end-of-stream": "^1.4.1",
-                "fs-constants": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.1.1"
             }
         },
         "test-exclude": {
@@ -3927,25 +3787,25 @@
             }
         },
         "vscode-jsonrpc": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz",
-            "integrity": "sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A=="
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+            "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg=="
         },
         "vscode-languageserver": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-6.1.1.tgz",
-            "integrity": "sha512-DueEpkUAkD5XTR4MLYNr6bQIp/UFR0/IPApgXU3YfCBCB08u2sm9hRCs6DxYZELkk++STPjpcjksR2H8qI3cDQ==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
+            "integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
             "requires": {
-                "vscode-languageserver-protocol": "^3.15.3"
+                "vscode-languageserver-protocol": "3.16.0"
             }
         },
         "vscode-languageserver-protocol": {
-            "version": "3.15.3",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz",
-            "integrity": "sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==",
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+            "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
             "requires": {
-                "vscode-jsonrpc": "^5.0.1",
-                "vscode-languageserver-types": "3.15.1"
+                "vscode-jsonrpc": "6.0.0",
+                "vscode-languageserver-types": "3.16.0"
             }
         },
         "vscode-languageserver-textdocument": {
@@ -3954,9 +3814,9 @@
             "integrity": "sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA=="
         },
         "vscode-languageserver-types": {
-            "version": "3.15.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
-            "integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ=="
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+            "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
         },
         "vscode-uri": {
             "version": "2.1.2",
@@ -4270,16 +4130,6 @@
             "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
             "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
             "dev": true
-        },
-        "zip-stream": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.3.tgz",
-            "integrity": "sha512-EkXc2JGcKhO5N5aZ7TmuNo45budRaFGHOmz24wtJR7znbNqDPmdZtUauKX6et8KAVseAMBOyWJqEpXcHTBsh7Q==",
-            "requires": {
-                "archiver-utils": "^2.1.0",
-                "compress-commons": "^2.1.1",
-                "readable-stream": "^3.4.0"
-            }
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -136,6 +136,11 @@
                 "to-fast-properties": "^2.0.0"
             }
         },
+        "@rokucommunity/bslib": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@rokucommunity/bslib/-/bslib-0.1.1.tgz",
+            "integrity": "sha512-2ox6EUL+UTtccTbD4dbVjZK3QHa0PHCqpoKMF8lZz9ayzzEP3iVPF8KZR6hOi6bxsIcbGXVjqmtCVkpC4P9SrA=="
+        },
         "@sinonjs/commons": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.0.tgz",
@@ -386,6 +391,16 @@
             "integrity": "sha512-9oRb68wEKT+MRB7e2GwTiKicRKVXKzquBDGgH6YcGafvnSYXorWi2oaTVtbv2109RlGiQSnoXaQFUXCnHwFS7Q==",
             "requires": {
                 "chevrotain": "7.1.1"
+            },
+            "dependencies": {
+                "chevrotain": {
+                    "version": "7.1.1",
+                    "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-7.1.1.tgz",
+                    "integrity": "sha512-wy3mC1x4ye+O+QkEinVJkPf5u2vsrDIYW9G7ZuwFl6v/Yu0LwUuT2POsb+NUWApebyxfkQq6+yDfRExbnI5rcw==",
+                    "requires": {
+                        "regexp-to-ast": "0.5.0"
+                    }
+                }
             }
         },
         "acorn": {
@@ -654,14 +669,15 @@
             }
         },
         "brighterscript": {
-            "version": "0.34.1",
-            "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.34.1.tgz",
-            "integrity": "sha512-1IHZ4w237+xJ5tbUu/TUl1m5dx/UrDW+VjRfpnDYueVQwXy/2C0p2A8UK2dmnyYDO7Edq7uTXpT8rcu06Yl1uw==",
+            "version": "0.37.3",
+            "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.37.3.tgz",
+            "integrity": "sha512-B/Op00MePl79wOc9b9W6o0tJTcHhwvA7mgz8ocx8n94+GWZJ+tISB+YtDSVLuagM4UcHCECtDqZJER0gRQBVEA==",
             "requires": {
+                "@rokucommunity/bslib": "^0.1.1",
                 "@xml-tools/parser": "^1.0.7",
                 "array-flat-polyfill": "^1.0.1",
-                "bslib": "npm:@rokucommunity/bslib@^0.1.1",
                 "chalk": "^2.4.2",
+                "chevrotain": "^7.0.1",
                 "chokidar": "^3.0.2",
                 "clear": "^0.1.0",
                 "cross-platform-clear-console": "^2.3.0",
@@ -685,7 +701,7 @@
                 "vscode-languageserver-textdocument": "^1.0.1",
                 "vscode-uri": "^2.1.1",
                 "xml2js": "^0.4.19",
-                "yargs": "^15.4.0"
+                "yargs": "^16.2.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -702,13 +718,13 @@
                     }
                 },
                 "cliui": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-                    "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+                    "version": "7.0.4",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+                    "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
                     "requires": {
                         "string-width": "^4.2.0",
                         "strip-ansi": "^6.0.0",
-                        "wrap-ansi": "^6.2.0"
+                        "wrap-ansi": "^7.0.0"
                     }
                 },
                 "color-convert": {
@@ -728,15 +744,6 @@
                     "version": "8.0.0",
                     "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
                     "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-                },
-                "find-up": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-                    "requires": {
-                        "locate-path": "^5.0.0",
-                        "path-exists": "^4.0.0"
-                    }
                 },
                 "fs-extra": {
                     "version": "7.0.1",
@@ -760,27 +767,6 @@
                     "requires": {
                         "graceful-fs": "^4.1.6"
                     }
-                },
-                "locate-path": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-                    "requires": {
-                        "p-locate": "^4.1.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-                    "requires": {
-                        "p-limit": "^2.2.0"
-                    }
-                },
-                "path-exists": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
                 },
                 "string-width": {
                     "version": "4.2.2",
@@ -806,41 +792,38 @@
                     "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
                 },
                 "wrap-ansi": {
-                    "version": "6.2.0",
-                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-                    "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+                    "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
                     "requires": {
                         "ansi-styles": "^4.0.0",
                         "string-width": "^4.1.0",
                         "strip-ansi": "^6.0.0"
                     }
                 },
+                "y18n": {
+                    "version": "5.0.8",
+                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+                    "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+                },
                 "yargs": {
-                    "version": "15.4.1",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-                    "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+                    "version": "16.2.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+                    "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
                     "requires": {
-                        "cliui": "^6.0.0",
-                        "decamelize": "^1.2.0",
-                        "find-up": "^4.1.0",
-                        "get-caller-file": "^2.0.1",
+                        "cliui": "^7.0.2",
+                        "escalade": "^3.1.1",
+                        "get-caller-file": "^2.0.5",
                         "require-directory": "^2.1.1",
-                        "require-main-filename": "^2.0.0",
-                        "set-blocking": "^2.0.0",
                         "string-width": "^4.2.0",
-                        "which-module": "^2.0.0",
-                        "y18n": "^4.0.0",
-                        "yargs-parser": "^18.1.2"
+                        "y18n": "^5.0.5",
+                        "yargs-parser": "^20.2.2"
                     }
                 },
                 "yargs-parser": {
-                    "version": "18.1.3",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-                    "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-                    "requires": {
-                        "camelcase": "^5.0.0",
-                        "decamelize": "^1.2.0"
-                    }
+                    "version": "20.2.7",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+                    "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw=="
                 }
             }
         },
@@ -849,11 +832,6 @@
             "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
             "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true
-        },
-        "bslib": {
-            "version": "npm:@rokucommunity/bslib@0.1.1",
-            "resolved": "https://registry.npmjs.org/@rokucommunity/bslib/-/bslib-0.1.1.tgz",
-            "integrity": "sha512-2ox6EUL+UTtccTbD4dbVjZK3QHa0PHCqpoKMF8lZz9ayzzEP3iVPF8KZR6hOi6bxsIcbGXVjqmtCVkpC4P9SrA=="
         },
         "buffer": {
             "version": "5.7.1",
@@ -940,9 +918,9 @@
             "dev": true
         },
         "chevrotain": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-7.1.1.tgz",
-            "integrity": "sha512-wy3mC1x4ye+O+QkEinVJkPf5u2vsrDIYW9G7ZuwFl6v/Yu0LwUuT2POsb+NUWApebyxfkQq6+yDfRExbnI5rcw==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-7.1.2.tgz",
+            "integrity": "sha512-9bQsXVQ7UAvzMs7iUBBJ9Yv//exOy7bIR3PByOEk4M64vIE/LsiOiX7VIkMF/vEMlrSStwsaE884Bp9CpjtC5g==",
             "requires": {
                 "regexp-to-ast": "0.5.0"
             }
@@ -1315,6 +1293,11 @@
             "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
             "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
             "dev": true
+        },
+        "escalade": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
         },
         "escape-string-regexp": {
             "version": "1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -267,6 +267,7 @@
             "version": "15.0.5",
             "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
             "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+            "dev": true,
             "requires": {
                 "@types/yargs-parser": "*"
             }
@@ -274,7 +275,8 @@
         "@types/yargs-parser": {
             "version": "15.0.0",
             "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
-            "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw=="
+            "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
+            "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
             "version": "2.29.0",
@@ -376,6 +378,14 @@
                         "tslib": "^1.8.1"
                     }
                 }
+            }
+        },
+        "@xml-tools/parser": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@xml-tools/parser/-/parser-1.0.9.tgz",
+            "integrity": "sha512-TB/EwgsJh9165k1NTapYyPIhgz4DEUnvmQhkj6Fvyfqc/0p9nFMg2kHuKroWg6Tjwr8y2gvi9wWVXerfXtrQ1w==",
+            "requires": {
+                "chevrotain": "7.1.0"
             }
         },
         "acorn": {
@@ -644,11 +654,11 @@
             }
         },
         "brighterscript": {
-            "version": "0.22.0",
-            "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.22.0.tgz",
-            "integrity": "sha512-It0ORUQMKwmuULTk05/WS8/tkuXY1k3V22e5H/GfN5KdphtiTkdCPyjpJiqgDbvtUozKY/dNPEdsM8TBmGAppg==",
+            "version": "0.29.0",
+            "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.29.0.tgz",
+            "integrity": "sha512-1KxTbIEZbAGrDduR5wBBkmUkdUZhDpS1pqHUgDttK6qTNTjEXkzZVuLDawKXrDV7GC5s5/HbWZohpsJuGSxeNw==",
             "requires": {
-                "@types/yargs": "^15.0.5",
+                "@xml-tools/parser": "^1.0.7",
                 "array-flat-polyfill": "^1.0.1",
                 "chalk": "^2.4.2",
                 "chokidar": "^3.0.2",
@@ -666,11 +676,11 @@
                 "moment": "^2.23.0",
                 "p-settle": "^2.1.0",
                 "parse-ms": "^2.1.0",
-                "path-complete-extname": "^1.0.0",
-                "roku-deploy": "^3.2.3",
+                "roku-deploy": "^3.2.4",
                 "serialize-error": "^7.0.1",
                 "source-map": "^0.7.3",
                 "vscode-languageserver": "^6.1.1",
+                "vscode-languageserver-protocol": "~3.15.3",
                 "vscode-languageserver-textdocument": "^1.0.1",
                 "vscode-uri": "^2.1.1",
                 "xml2js": "^0.4.19",
@@ -922,6 +932,14 @@
             "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
             "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
             "dev": true
+        },
+        "chevrotain": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-7.1.0.tgz",
+            "integrity": "sha512-msTqYIGb+8z4UpNxliBlowlfFJtBQjTSdnOWgMD/llcE5cQHDbFMjHGdCMJSsPG/Op89c6/ERCmYku4UHDhHVA==",
+            "requires": {
+                "regexp-to-ast": "0.5.0"
+            }
         },
         "child-process-promise": {
             "version": "2.2.1",
@@ -2984,11 +3002,6 @@
                 "util": "^0.10.3"
             }
         },
-        "path-complete-extname": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/path-complete-extname/-/path-complete-extname-1.0.0.tgz",
-            "integrity": "sha512-CVjiWcMRdGU8ubs08YQVzhutOR5DEfO97ipRIlOGMK5Bek5nQySknBpuxVAVJ36hseTNs+vdIcv57ZrWxH7zvg=="
-        },
         "path-exists": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -3157,6 +3170,11 @@
                 "picomatch": "^2.0.4"
             }
         },
+        "regexp-to-ast": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
+            "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw=="
+        },
         "regexpp": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
@@ -3260,9 +3278,9 @@
             }
         },
         "roku-deploy": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.2.3.tgz",
-            "integrity": "sha512-4h3yDAQl7uHzVjvu4XtvQJOYeKfBBhWcM3ss46RVT8HqYZdMJ5+kVP2+oPymA3U3pzGvtoSI/OuM0JG/VSNyGg==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.2.4.tgz",
+            "integrity": "sha512-teZB4sRWS2EVHx8KWSqHW4QS9B2Z5jD5MrZrbdikl3thMljdVkbGLkarxrFw1NZfMR6nf0b0XXygOWjvePIeuw==",
             "requires": {
                 "archiver": "^3.0.0",
                 "dateformat": "^3.0.3",
@@ -3630,9 +3648,9 @@
             }
         },
         "tar-stream": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
-            "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
             "requires": {
                 "bl": "^4.0.3",
                 "end-of-stream": "^1.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -654,9 +654,9 @@
             }
         },
         "brighterscript": {
-            "version": "0.33.0",
-            "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.33.0.tgz",
-            "integrity": "sha512-f7tcneebDxRpIzRqxZDMQHQII+FaL4SBtdmUAsp+419ThqFRPAeJZM0vTIVyAQF9wi8WRDfGug5IrygUwAnJMg==",
+            "version": "0.34.1",
+            "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.34.1.tgz",
+            "integrity": "sha512-1IHZ4w237+xJ5tbUu/TUl1m5dx/UrDW+VjRfpnDYueVQwXy/2C0p2A8UK2dmnyYDO7Edq7uTXpT8rcu06Yl1uw==",
             "requires": {
                 "@xml-tools/parser": "^1.0.7",
                 "array-flat-polyfill": "^1.0.1",
@@ -783,9 +783,9 @@
                     "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
                 },
                 "string-width": {
-                    "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.1.tgz",
-                    "integrity": "sha512-LL0OLyN6AnfV9xqGQpDBwedT2Rt63737LxvsRxbcwpa2aIeynBApG2Sm//F3TaLHIR1aJBN52DWklc06b94o5Q==",
+                    "version": "4.2.2",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+                    "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
                     "requires": {
                         "emoji-regex": "^8.0.0",
                         "is-fullwidth-code-point": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "brighterscript-formatter": "dist/cli.js"
     },
     "dependencies": {
-        "brighterscript": "^0.29.0",
+        "brighterscript": "^0.33.0",
         "glob-all": "^3.2.1",
         "jsonc-parser": "^2.3.0",
         "source-map": "^0.7.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "brighterscript-formatter": "dist/cli.js"
     },
     "dependencies": {
-        "brighterscript": "^0.22.0",
+        "brighterscript": "^0.29.0",
         "glob-all": "^3.2.1",
         "jsonc-parser": "^2.3.0",
         "source-map": "^0.7.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "brighterscript-formatter": "dist/cli.js"
     },
     "dependencies": {
-        "brighterscript": "^0.34.1",
+        "brighterscript": "^0.37.3",
         "glob-all": "^3.2.1",
         "jsonc-parser": "^2.3.0",
         "source-map": "^0.7.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "brighterscript-formatter": "dist/cli.js"
     },
     "dependencies": {
-        "brighterscript": "^0.37.3",
+        "brighterscript": "^0.39.3",
         "glob-all": "^3.2.1",
         "jsonc-parser": "^2.3.0",
         "source-map": "^0.7.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "brighterscript-formatter": "dist/cli.js"
     },
     "dependencies": {
-        "brighterscript": "^0.33.0",
+        "brighterscript": "^0.34.1",
         "glob-all": "^3.2.1",
         "jsonc-parser": "^2.3.0",
         "source-map": "^0.7.3",

--- a/src/Formatter.spec.ts
+++ b/src/Formatter.spec.ts
@@ -61,47 +61,47 @@ describe('Formatter', () => {
                     if b = 1
                         print "1"
                     end if
-                
+
                     if b = 1 then
                         print "1"
                     end if
-                
+
                     if b = 1
                         print "1"
                     else
                         print "1"
                     end if
-                
+
                     if b = 1 then
                         print "1"
                     else
                         print "1"
                     end if
-                
+
                     if b = 1
                         print "1"
                     else if b = 1
                         print "1"
                     end if
-                
+
                     if b = 1
                         print "1"
                     else if b = 1 then
                         print "1"
                     end if
-                
+
                     if b = 1 then
                         print "1"
                     else if b = 1
                         print "1"
                     end if
-                
+
                     if b = 1 then
                         print "1"
                     else if b = 1 then
                         print "1"
                     end if
-                
+
                     if b = 1
                         print "1"
                     else if b = 1
@@ -109,7 +109,7 @@ describe('Formatter', () => {
                     else
                         print "1"
                     end if
-                
+
                     if b = 1 then
                         print "1"
                     else if b = 1
@@ -117,7 +117,7 @@ describe('Formatter', () => {
                     else
                         print "1"
                     end if
-                
+
                     if b = 1
                         print "1"
                     else if b = 1 then
@@ -125,7 +125,7 @@ describe('Formatter', () => {
                     else
                         print "1"
                     end if
-                
+
                     if b = 1 then
                         print "1"
                     else if b = 1 then

--- a/src/Formatter.spec.ts
+++ b/src/Formatter.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import { Formatter } from './Formatter';
 import { FormattingOptions } from './FormattingOptions';
-import { createToken, Token, TokenKind, util } from 'brighterscript';
+import { createToken, Token, TokenKind } from 'brighterscript';
 import { SourceMapConsumer } from 'source-map';
 
 describe('Formatter', () => {

--- a/src/Formatter.spec.ts
+++ b/src/Formatter.spec.ts
@@ -19,6 +19,21 @@ describe('Formatter', () => {
     });
 
     describe('formatIndent', () => {
+        it('formats simple if statement', () => {
+            formatEqualTrim(`
+                if true then
+                    print "if"
+                end if
+                if true then
+                    print "if"
+                else if false then
+                    print "else if"
+                else
+                    print "else"
+                end if
+            `);
+        });
+
         it('property indents try catch statements', () => {
             formatEqualTrim(`
                 try
@@ -833,6 +848,17 @@ end sub`;
     });
 
     describe('compositeKeywords', () => {
+        it(`works for 'combine'`, () => {
+            expect(formatter.format(
+                `elseif`,
+                {
+                    compositeKeywords: 'combine'
+                }
+            )).to.equal(
+                `elseif`
+            );
+        });
+
         it(`works for 'combine'`, () => {
             expect(formatter.format(
                 `function a()\nend function`,

--- a/src/Formatter.ts
+++ b/src/Formatter.ts
@@ -297,20 +297,20 @@ export class Formatter {
                 indexOffset += offsetDifference;
 
                 //`else if` is a special case
-            } else if (token.kind === TokenKind.Else && nextNonWhitespaceToken?.kind === TokenKind.If) {
+            } else if (token.kind === TokenKind.Else && nextNonWhitespaceToken && nextNonWhitespaceToken.kind === TokenKind.If) {
                 const nextToken = tokens[i + 1];
 
                 //remove separating Whitespace
                 if (options.compositeKeywords === 'combine') {
                     //if there is a whitespace token between the `else` and `if`
-                    if (nextToken?.kind === TokenKind.Whitespace) {
+                    if (nextToken.kind === TokenKind.Whitespace) {
                         //remove the whitespace token
                         tokens.splice(i + 1, 1);
                     }
 
                     //separate with exactly 1 space
                 } else if (options.compositeKeywords === 'split') {
-                    if (nextToken?.kind !== TokenKind.Whitespace) {
+                    if (nextToken.kind !== TokenKind.Whitespace) {
                         tokens.splice(i + 1, 0, createToken(TokenKind.Whitespace, ' '));
                     } else {
                         nextToken.text = ' ';
@@ -619,14 +619,16 @@ export class Formatter {
      * Then return the endIf token if it exists
      */
     private getEndIfToken(ifStatement: IfStatement | undefined) {
-        while (true) {
-            if (!isIfStatement(ifStatement?.elseBranch)) {
-                break;
-            } else {
-                ifStatement = ifStatement?.elseBranch;
+        if (isIfStatement(ifStatement)) {
+            while (true) {
+                if (isIfStatement(ifStatement.elseBranch)) {
+                    ifStatement = ifStatement.elseBranch;
+                } else {
+                    break;
+                }
             }
+            return ifStatement.tokens.endIf;
         }
-        return ifStatement?.tokens.endIf;
     }
 
     /**


### PR DESCRIPTION
There were several significant changes to the brighterscript parser, and we want to keep this project up-to-date, so this makes the necessary changes.

 - brighterscript changed the structure of if statements to be nested rather than have them all in a single statement.
 - there is no `elseif` token anymore, in favor of using separate `else` and `if` tokens

None of this has any practical impact on the formatter, it just keeps us in sync for the future.