### PR TITLE
Fix as token spacing

### DIFF
--- a/src/Formatter.spec.ts
+++ b/src/Formatter.spec.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-
 import { Formatter } from './Formatter';
 import { FormattingOptions } from './FormattingOptions';
 import { createToken, Token, TokenKind } from 'brighterscript';
@@ -316,6 +315,18 @@ describe('Formatter', () => {
     });
 
     describe('formatInteriorWhitespace', () => {
+        it('inserts space around `as` token', () => {
+            formatEqualTrim(`
+                function GetBoolean(   as    as    string  )as boolean
+                    return true
+                end function
+            `, `
+                function GetBoolean(as as string) as boolean
+                    return true
+                end function
+            `);
+        });
+
         describe('insertSpaceBetweenAssociativeArrayLiteralKeyAndColon', () => {
             it('adds space for inline objects', () => {
                 formatEqual(`def = { "key": "value" }`, `def = { "key" : "value" }`, {

--- a/src/Formatter.ts
+++ b/src/Formatter.ts
@@ -661,7 +661,10 @@ export class Formatter {
             TokenKind.LessEqual,
             TokenKind.GreaterEqual,
             TokenKind.Greater,
-            TokenKind.Less
+            TokenKind.Less,
+
+            //keywords
+            TokenKind.As
         ];
         let addLeft = [
             ...addBoth,


### PR DESCRIPTION
Add space around the `as` token in function statements. 

Fixes #38 