### PR TITLE
Fix formatting issue with ternary and square brace

### DIFF
--- a/src/Formatter.spec.ts
+++ b/src/Formatter.spec.ts
@@ -190,6 +190,24 @@ describe('Formatter', () => {
                 end sub
            `);
         });
+
+        it('handles array in ternary properly', () => {
+            formatEqualTrim(`
+                sub main()
+                    a = true ? [] : true
+                    print a
+                end sub
+           `);
+        });
+
+        it('handles wrapped anon function in ternary properly', () => {
+            formatEqualTrim(`
+                sub main()
+                    a = true ? (sub() : print hello : end sub) : true
+                    print a
+                end sub
+           `);
+        });
     });
 
     describe('formatMultiLineObjectsAndArrays', () => {


### PR DESCRIPTION
Fixes #43 .

This is more of a partial fix. The underlying issue is that we can't distinguish between a colon in a ternary expression and a colon in   an associative array literal. Since `]` and `}` can't be used as array keys, we can be confident those are not keys in an AA literal and therefore we exclude them from consideration. 

This means we still will have formatting issues for something like this:
```
a = true ? sub() : print hello : end sub : true
```

However, users can work around that by wrapping the expression in parens, so the fix is probably good enough for now:
```
 a = true ? (sub() : print hello : end sub) : true
```
