### PR TITLE
Properly formats an interface that includes subs, functions

### DIFF
--- a/bsfmt.schema.json
+++ b/bsfmt.schema.json
@@ -161,6 +161,15 @@
                         "original"
                     ]
                 },
+                "endinterface": {
+                    "type": "string",
+                    "enum": [
+                        "lower",
+                        "upper",
+                        "title",
+                        "original"
+                    ]
+                },
                 "endnamespace": {
                     "type": "string",
                     "enum": [

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "brighterscript-formatter": "dist/cli.js"
     },
     "dependencies": {
-        "brighterscript": "../brighterscript",
+        "brighterscript": "^0.42.0",
         "glob-all": "^3.2.1",
         "jsonc-parser": "^3.0.0",
         "source-map": "^0.7.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "brighterscript-formatter": "dist/cli.js"
     },
     "dependencies": {
-        "brighterscript": "^0.42.0",
+        "brighterscript": "../brighterscript",
         "glob-all": "^3.2.1",
         "jsonc-parser": "^3.0.0",
         "source-map": "^0.7.3",

--- a/src/Formatter.spec.ts
+++ b/src/Formatter.spec.ts
@@ -311,6 +311,10 @@ describe('Formatter', () => {
         it(`does not indent object properties called 'endnamespace'`, () => {
             formatEqual(`sub main()\n    if m.endnamespace = 123\n        print true\n    end if\nend sub`);
         });
+
+        it(`does not indent object properties called 'endinterface'`, () => {
+            formatEqual(`sub main()\n    if m.endinterface = 123\n        print true\n    end if\nend sub`);
+        });
     });
 
     describe('dedupeWhitespace', () => {
@@ -603,6 +607,14 @@ end sub`;
                 'interface Person\nname as string\nend interface'
             )).to.equal(
                 'interface Person\n    name as string\nend interface'
+            );
+        });
+
+        it('correctly indents interface declarations that contain functions or subs', () => {
+            expect(formatter.format(
+                'interface Person\nname as string\nsub talk(words as string)\nfunction getAge() as integer\nend interface'
+            )).to.equal(
+                'interface Person\n    name as string\n    sub talk(words as string)\n    function getAge() as integer\nend interface'
             );
         });
 

--- a/src/Formatter.spec.ts
+++ b/src/Formatter.spec.ts
@@ -618,6 +618,14 @@ end sub`;
             );
         });
 
+        it('correctly indents multiple interfaces', () => {
+            expect(formatter.format(
+                'interface IFaceA\na as string\nsub doA()\nend interface\ninterface IFaceB\nb as string\nsub doB()\nend interface'
+            )).to.equal(
+                'interface IFaceA\n    a as string\n    sub doA()\nend interface\ninterface IFaceB\n    b as string\n    sub doB()\nend interface'
+            );
+        });
+
         it('correctly indents class methods with access modifiers', () => {
             expect(formatter.format(
                 'class Person\npublic sub a()\nend sub\nprotected sub b()\nend sub\nprivate sub c()\nend sub\nend class'

--- a/src/Formatter.ts
+++ b/src/Formatter.ts
@@ -1248,7 +1248,8 @@ export let IndentSpacerTokenKinds = [
 ];
 
 /**
- * The list of tokens that should not cause an indent in an interface
+ * A map of tokenKinds that should not cause an indent keyed by the parent token kind
+ * E.g. In 'interface', 'sub' and 'function' should not be indented
  */
 export let IgnoreIndentSpacerByParentTokenKind = new Map<TokenKind, TokenKind[]>([
     [TokenKind.Interface, [


### PR DESCRIPTION
Adds new logic that allows the indent/outdent code to ignore certain indents based on the "parent" indent.

In particular, if the parent  token is `interface`, then indents for `sub` and `function` are ignored.