### PR TITLE
Better support for appropriate whitespace between minus and numbers/identifiers -  Fixes #20

### DIFF
--- a/src/Formatter.spec.ts
+++ b/src/Formatter.spec.ts
@@ -465,6 +465,16 @@ describe('Formatter', () => {
             formatEqual(`a = [1, -24]`);
             formatEqual(`a = [-24]`);
             formatEqual(`a(-24)`);
+            formatEqual(`if -1 = value\nend if`);
+            formatEqual(`while -1 = value\nend while`);
+            formatEqual(`print -1 + 2`);
+            formatEqual(`print -1 + -1`);
+            expect(formatter.format(`print - 1 + - 1`)).to.equal(`print -1 + -1`);
+            formatEqual(`value = -value`);
+            expect(formatter.format(`value=-value- -value`)).to.equal(`value = -value - -value`);
+            formatEqual(`while -value < 0\nend while`);
+            formatEqual(`if condition and -1 <> value\nend if`);
+            formatEqual(`if condition or -1 <> value\nend if`);
         });
 
         it('works for special cases', () => {

--- a/src/Formatter.spec.ts
+++ b/src/Formatter.spec.ts
@@ -470,11 +470,22 @@ describe('Formatter', () => {
             formatEqual(`print -1 + 2`);
             formatEqual(`print -1 + -1`);
             expect(formatter.format(`print - 1 + - 1`)).to.equal(`print -1 + -1`);
-            formatEqual(`value = -value`);
-            expect(formatter.format(`value=-value- -value`)).to.equal(`value = -value - -value`);
-            formatEqual(`while -value < 0\nend while`);
             formatEqual(`if condition and -1 <> value\nend if`);
             formatEqual(`if condition or -1 <> value\nend if`);
+            formatEqual(`if condition and not -1 <> value\nend if`);
+        });
+
+        it('correctly formats negated variable identifier', () => {
+            formatEqual(`value = -value`);
+            expect(formatter.format(`value=1-value`)).to.equal(`value = 1 - value`);
+            expect(formatter.format(`value=1- -value`)).to.equal(`value = 1 - -value`);
+            expect(formatter.format(`value=-value- -value`)).to.equal(`value = -value - -value`);
+            formatEqual(`while -value < 0\nend while`);
+            formatEqual(`if condition and -value <> -1\nend if`);
+            formatEqual(`if condition or -1 <> -value\nend if`);
+            formatEqual(`if condition and not -1 <> -value\nend if`);
+            expect(formatter.format(`if condition and not - 1 <> - value\nend if`)).to.equal(`if condition and not -1 <> -value\nend if`);
+
         });
 
         it('works for special cases', () => {

--- a/src/Formatter.spec.ts
+++ b/src/Formatter.spec.ts
@@ -479,6 +479,7 @@ describe('Formatter', () => {
             formatEqual(`value = -value`);
             expect(formatter.format(`value=1-value`)).to.equal(`value = 1 - value`);
             expect(formatter.format(`value=1- -value`)).to.equal(`value = 1 - -value`);
+            expect(formatter.format(`value=1- -  value`)).to.equal(`value = 1 - -value`);
             expect(formatter.format(`value=-value- -value`)).to.equal(`value = -value - -value`);
             formatEqual(`while -value < 0\nend while`);
             formatEqual(`if condition and -value <> -1\nend if`);

--- a/src/Formatter.ts
+++ b/src/Formatter.ts
@@ -760,6 +760,12 @@ export class Formatter {
                         this.removeWhitespace(tokens, i + 1);
                     }
                     //ensure a space token to the right, only if we have more tokens to the right available
+                } else if (this.looksLikeNegativeVariable(tokens, i)) {
+                    //throw out the space to the right of the minus symbol if present
+                    if (i + 1 < tokens.length && tokens[i + 1].kind === TokenKind.Whitespace) {
+                        this.removeWhitespace(tokens, i + 1);
+                    }
+                    //ensure a space token to the right, only if we have more tokens to the right available
                 } else if (nextTokenType && ![TokenKind.Whitespace, TokenKind.Newline, TokenKind.Eof].includes(nextTokenType)) {
                     //don't add Whitespace if the next token is the Newline
 
@@ -1021,6 +1027,27 @@ export class Formatter {
                 nextToken &&
                 //next non-Whitespace token is a numeric literal
                 NumericLiteralTokenKinds.includes(nextToken.kind) &&
+                previousToken &&
+                TokensBeforeNegativeNumericLiteral.includes(previousToken.kind)
+            ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Determine if the current token appears to be the negative sign for a variable identifier token
+     */
+    private looksLikeNegativeVariable(tokens: Token[], index: number) {
+        let thisToken = tokens[index];
+        if (thisToken.kind === TokenKind.Minus) {
+            let nextToken = this.getNextNonWhitespaceToken(tokens, index);
+            let previousToken = this.getPreviousNonWhitespaceToken(tokens, index);
+            if (
+                nextToken &&
+                //next non-Whitespace token is an identifier
+                nextToken.kind === TokenKind.Identifier &&
                 previousToken &&
                 TokensBeforeNegativeNumericLiteral.includes(previousToken.kind)
             ) {
@@ -1331,7 +1358,12 @@ export let TokensBeforeNegativeNumericLiteral = [
     TokenKind.Semicolon,
     TokenKind.Comma,
     TokenKind.LeftSquareBracket,
-    TokenKind.LeftParen
+    TokenKind.LeftParen,
+    TokenKind.If,
+    TokenKind.Print,
+    TokenKind.While,
+    TokenKind.Or,
+    TokenKind.And
 ];
 
 export const TypeTokens = [

--- a/src/Formatter.ts
+++ b/src/Formatter.ts
@@ -1363,7 +1363,8 @@ export let TokensBeforeNegativeNumericLiteral = [
     TokenKind.Print,
     TokenKind.While,
     TokenKind.Or,
-    TokenKind.And
+    TokenKind.And,
+    TokenKind.Not
 ];
 
 export const TypeTokens = [


### PR DESCRIPTION
Fixes #20 

- Added TokenKinds commonly found in conditions (and or not, etc) to the list of `TokensBeforeNegativeNumericLiteral`
- Added a check if it's not a numeric literal, but instead a variable identifier, and it does the same.
