### PR TITLE
Break `process` into smaller functions

### DIFF
--- a/src/Formatter.spec.ts
+++ b/src/Formatter.spec.ts
@@ -4,6 +4,7 @@ import type { FormattingOptions } from './FormattingOptions';
 import type { Token } from 'brighterscript';
 import { createToken, TokenKind } from 'brighterscript';
 import { SourceMapConsumer } from 'source-map';
+import { undent } from 'undent';
 
 describe('Formatter', () => {
     let formatter: Formatter;
@@ -887,8 +888,17 @@ end sub`;
         });
 
         it('handles resetting outdent when gone into the negative', () => {
-            let program = `sub test()\n    if true then\n        doSomething()\n    end if\nend if\nend sub\nsub test2()\n    doSomething()\nend sub`;
-            expect(formatter.format(program)).to.equal(program);
+            formatEqual(undent`
+                sub test()
+                    if true then
+                        doSomething()
+                    end if
+                end if 'out of place "end if" shouldn't kill lower formatting
+                end sub
+                sub test2()
+                    doSomething()
+                end sub
+            `);
         });
 
         it('it works with identifiers that start with rem', () => {

--- a/src/formatters/IndentFormatter.spec.ts
+++ b/src/formatters/IndentFormatter.spec.ts
@@ -1,0 +1,80 @@
+import { expect } from 'chai';
+import { expectTokens, lex } from '../testHelpers.spec';
+import { IndentFormatter } from './IndentFormatter';
+
+describe('IndentFormatter', () => {
+    let formatter: IndentFormatter;
+
+    beforeEach(() => {
+        formatter = new IndentFormatter();
+    });
+
+    describe('ensureTokenIndentation', () => {
+        it('does nothing for empty or invalid tokens', () => {
+            expect(
+                formatter['ensureTokenIndentation'](null as any, 0)
+            ).to.eql(null);
+            expect(
+                formatter['ensureTokenIndentation']([], 0)
+            ).to.eql([]);
+        });
+
+        it('handles negative tab size', () => {
+            expectTokens(
+                formatter['ensureTokenIndentation'](lex(`\tspeak()`), -2),
+                ['', 'speak', '(', ')']
+            );
+        });
+
+        it('does not add whitespace token if no indentation is needed', () => {
+            expectTokens(
+                formatter['ensureTokenIndentation'](lex(`speak()`), 0),
+                ['speak', '(', ')']
+            );
+        });
+
+        it('dedupes side-by-side whitespace tokens into one', () => {
+            expectTokens(
+                formatter['ensureTokenIndentation'](lex(` \t speak()`), 1),
+                ['    ', 'speak', '(', ')']
+            );
+        });
+
+        it('adds whitespace when missing', () => {
+            expectTokens(
+                formatter['ensureTokenIndentation'](lex(`speak()`), 1),
+                ['    ', 'speak', '(', ')']
+            );
+        });
+
+        it('adds correct indentation when missing', () => {
+            expectTokens(
+                formatter['ensureTokenIndentation'](lex(`speak()`), 3),
+                ['            ', 'speak', '(', ')']
+            );
+        });
+
+        it('uses supplied indentation char when provided', () => {
+            expectTokens(
+                formatter['ensureTokenIndentation'](lex(`speak()`), 3, '\t'),
+                ['\t\t\t', 'speak', '(', ')']
+            );
+        });
+    });
+
+    describe('trimWhitespaceOnlyLines', () => {
+        it('trims whitespace-only lines', () => {
+            expectTokens(
+                formatter['trimWhitespaceOnlyLines'](lex(` `)),
+                []
+            );
+        });
+
+        it('leaves non-whitespace-only lines intact', () => {
+            expectTokens(
+                formatter['trimWhitespaceOnlyLines'](lex(` speak()`)),
+                [' ', 'speak', '(', ')']
+            );
+        });
+    });
+});

--- a/src/formatters/IndentFormatter.ts
+++ b/src/formatters/IndentFormatter.ts
@@ -10,11 +10,238 @@ export class IndentFormatter {
      * Handle indentation for an array of tokens
      */
     public process(tokens: Token[], options: FormattingOptions, parser: Parser) {
-        let tabCount = 0;
+        // The text used for each tab
+        let tabText = options.indentStyle === 'tabs' ? '\t' : ' '.repeat(options.indentSpaceCount ?? DEFAULT_INDENT_SPACE_COUNT);
+
+        //the tab count as it flows through the program. Starting point for each line's tabCount calculation.
+        let globalTabCount = 0;
+
+        //get a map of all if statements for easier lookups
+        const ifStatements = this.getAllIfStatements(parser);
+
+        let parentIndentTokenKinds: TokenKind[] = [];
+
+        //the list of output tokens
+        let result: Token[] = [];
+
+        //set the loop to run for a max of double the number of tokens we found so we don't end up with an infinite loop
+        for (let lineTokens of this.splitTokensByLine(tokens)) {
+            const { currentLineOffset, nextLineOffset } = this.processLine(lineTokens, tokens, ifStatements, parentIndentTokenKinds);
+
+            //compute the current line's tab count (default to 0 if we somehow went negative)
+            let currentLineTabCount = Math.max(globalTabCount + currentLineOffset, 0);
+
+            //update the offset for the next line (default to 0 if we somehow went negative)
+            globalTabCount = Math.max(globalTabCount + nextLineOffset, 0);
+
+            this.ensureTokenIndentation(lineTokens, currentLineTabCount, tabText);
+            this.trimWhitespaceOnlyLines(lineTokens);
+
+            //push these tokens to the result list
+            result.push(...lineTokens);
+        }
+        return result;
+    }
+
+    private processLine(
+        lineTokens: Token[],
+        tokens: Token[],
+        ifStatements: Map<Token, IfStatement>,
+        parentIndentTokenKinds: TokenKind[]
+    ): { currentLineOffset: number; nextLineOffset: number } {
+        const getParentIndentTokenKind = () => {
+            return parentIndentTokenKinds.length > 0 ? parentIndentTokenKinds[parentIndentTokenKinds.length - 1] : undefined;
+        };
+
+        let currentLineOffset = 0;
+        let nextLineOffset = 0;
+        let foundIndentorThisLine = false;
+
+        for (let i = 0; i < lineTokens.length; i++) {
+            let token = lineTokens[i];
+            let previousNonWhitespaceToken = util.getPreviousNonWhitespaceToken(lineTokens, i);
+            let nextNonWhitespaceToken = util.getNextNonWhitespaceToken(lineTokens, i);
+
+            //if the previous token was `else` and this token is `if`, skip this token. (we used to have a single token for `elseif` but it got split out in an update of brighterscript)
+            if (previousNonWhitespaceToken?.kind === TokenKind.Else && token.kind === TokenKind.If) {
+                continue;
+            }
+
+            if (
+                //if this is an indentor token
+                IndentSpacerTokenKinds.includes(token.kind) &&
+                //is not being used as a key in an AA literal
+                nextNonWhitespaceToken && nextNonWhitespaceToken.kind !== TokenKind.Colon
+            ) {
+                //skip indent for 'function'|'sub' used as type (preceeded by `as` keyword)
+                if (
+                    CallableKeywordTokenKinds.includes(token.kind) &&
+                    //the previous token will be Whitespace, so verify that previousPrevious is 'as'
+                    previousNonWhitespaceToken?.kind === TokenKind.As
+                ) {
+                    continue;
+                }
+
+                //skip indent for single-line if statements
+                let ifStatement = ifStatements.get(token);
+                const endIfToken = this.getEndIfToken(ifStatement);
+                if (
+                    ifStatement &&
+                    (
+                        //does not have an end if
+                        !endIfToken ||
+                        //end if is on same line as if
+                        ifStatement.tokens.if.range.end.line === endIfToken.range.end.line
+                    )
+                ) {
+                    //if there's an `else`, skip past it since it'll cause de-indent otherwise
+                    if (ifStatement.tokens.else) {
+                        i = tokens.indexOf(ifStatement.tokens.else);
+                    }
+
+                    continue;
+                }
+
+                // check for specifically mentioned tokens to NOT indent
+                const parentIndentTokenKind = getParentIndentTokenKind();
+                if (parentIndentTokenKind && IgnoreIndentSpacerByParentTokenKind.get(parentIndentTokenKind)?.includes(token.kind)) {
+                    // This particular token should not be indented because it is listed in the ignore group for its parent
+                    continue;
+                }
+
+                nextLineOffset++;
+                foundIndentorThisLine = true;
+                parentIndentTokenKinds.push(token.kind);
+
+
+                //don't double indent if this is `[[...\n...]]` or `[{...\n...}]`
+                if (
+                    //is open square
+                    token.kind === TokenKind.LeftSquareBracket &&
+                    //next is an open curly or square
+                    (nextNonWhitespaceToken.kind === TokenKind.LeftCurlyBrace || nextNonWhitespaceToken.kind === TokenKind.LeftSquareBracket) &&
+                    //both tokens are on the same line
+                    token.range.start.line === nextNonWhitespaceToken.range.start.line
+                ) {
+                    //find the closer
+                    let closer = util.getClosingToken(tokens, tokens.indexOf(token), TokenKind.LeftSquareBracket, TokenKind.RightSquareBracket);
+                    let expectedClosingPreviousKind = nextNonWhitespaceToken.kind === TokenKind.LeftSquareBracket ? TokenKind.RightSquareBracket : TokenKind.RightCurlyBrace;
+                    let closingPrevious = closer && util.getPreviousNonWhitespaceToken(tokens, tokens.indexOf(closer), true);
+                    /* istanbul ignore else (because I can't figure out how to make this happen but I think it's still necessary) */
+                    if (closingPrevious && closingPrevious.kind === expectedClosingPreviousKind) {
+                        //skip the next token
+                        i++;
+                    }
+                }
+            } else if (this.isOutdentToken(token, nextNonWhitespaceToken)) {
+                //do not un-indent if this is a `next` or `endclass` token preceeded by a period
+                if (
+                    [TokenKind.Next, TokenKind.EndClass, TokenKind.Namespace, TokenKind.EndNamespace].includes(token.kind) &&
+                    previousNonWhitespaceToken && previousNonWhitespaceToken.kind === TokenKind.Dot
+                ) {
+                    continue;
+                }
+
+                nextLineOffset--;
+                if (foundIndentorThisLine === false) {
+                    currentLineOffset--;
+                }
+                parentIndentTokenKinds.pop();
+
+                //don't double un-indent if this is `[[...\n...]]` or `[{...\n...}]`
+                if (
+                    //is closing curly or square
+                    (token.kind === TokenKind.RightCurlyBrace || token.kind === TokenKind.RightSquareBracket) &&
+                    //next is closing square
+                    nextNonWhitespaceToken && nextNonWhitespaceToken.kind === TokenKind.RightSquareBracket &&
+                    //both tokens are on the same line
+                    token.range.start.line === nextNonWhitespaceToken.range.start.line
+                ) {
+                    let opener = this.getOpeningToken(
+                        tokens,
+                        tokens.indexOf(nextNonWhitespaceToken),
+                        TokenKind.LeftSquareBracket,
+                        TokenKind.RightSquareBracket
+                    );
+                    let openerNext = opener && util.getNextNonWhitespaceToken(tokens, tokens.indexOf(opener), true);
+                    if (openerNext && (openerNext.kind === TokenKind.LeftCurlyBrace || openerNext.kind === TokenKind.LeftSquareBracket)) {
+                        //skip the next token
+                        i += 1;
+                        continue;
+                    }
+                }
+
+                //this is an interum token
+            } else if (InterumSpacingTokenKinds.includes(token.kind)) {
+                //these need outdented, but don't change the tabCount
+                currentLineOffset--;
+            }
+            //  else if (token.kind === TokenKind.return && foundIndentorThisLine) {
+            //     //a return statement on the same line as an indentor means we don't want to indent
+            //     tabCount--;
+            // }
+        }
+        return {
+            currentLineOffset: currentLineOffset,
+            nextLineOffset: nextLineOffset
+        };
+    }
+
+    /**
+     * Ensure the list of tokens contains the correct number of tabs
+     * @param tokens the array of tokens to be modified in-place
+     * @param tabCount the number of tabs to indent the tokens by
+     * @param tabText the string to use for each tab. For tabs, this is "\t", for spaces it would be something like "    " or "  "
+     */
+    private ensureTokenIndentation(tokens: Token[], tabCount: number, tabText = '    '): Token[] {
+        //do nothing if we have an empty tokens list
+        if (!tokens || tokens.length === 0) {
+            return tokens;
+        }
+
+        //merge all duplicate whitespace tokens into a single token
+        util.dedupeWhitespace(tokens, true);
+
+        //ensure there's a leading whitespace token if we're going to be adding whitespace
+        if (tokens[0].kind !== TokenKind.Whitespace && tabCount > 0) {
+            tokens.unshift({
+                startIndex: -1,
+                kind: TokenKind.Whitespace,
+                text: ''
+            } as TokenWithStartIndex);
+        }
+
+        if (tokens[0].kind === TokenKind.Whitespace) {
+            tabCount = tabCount >= 0 ? tabCount : 0;
+            //replace a whitespace's token text with the current indentation whitespace
+            tokens[0].text = tabText.repeat(tabCount);
+        }
+        return tokens;
+    }
+
+    /**
+     * Removing leading whitespace from whitespace-only lines.
+     * This should only be called once the line has been whitespace-deduped
+     */
+    private trimWhitespaceOnlyLines(tokens: Token[]) {
+        //if the first token is whitespace, and the next is EOL or EOF
+        if (
+            tokens[0].kind === TokenKind.Whitespace &&
+            tokens.length === 2 &&
+            (tokens[1].kind === TokenKind.Newline || tokens[1].kind === TokenKind.Eof)
+        ) {
+            tokens.splice(0, 1);
+        }
+        return tokens;
+    }
+
+    /**
+     * Find all if statements in this file
+     */
+    private getAllIfStatements(parser: Parser) {
 
         const ifStatements = new Map<Token, IfStatement>();
 
-        //create a map of all if statements for easier lookups
         parser.ast.walk(createVisitor({
             IfStatement: (statement) => {
                 ifStatements.set(statement.tokens.if, statement);
@@ -22,203 +249,26 @@ export class IndentFormatter {
         }), {
             walkMode: WalkMode.visitAllRecursive
         });
+        return ifStatements;
+    }
 
-        let nextLineStartTokenIndex = 0;
-        let parentIndentTokenKinds: TokenKind[] = [];
-
-        const getParentIndentTokenKind = () => {
-            return parentIndentTokenKinds.length > 0 ? parentIndentTokenKinds[parentIndentTokenKinds.length - 1] : undefined;
-        };
-
-        //the list of output tokens
-        let outputTokens: Token[] = [];
-        //set the loop to run for a max of double the number of tokens we found so we don't end up with an infinite loop
-        for (let outerLoopCounter = 0; outerLoopCounter <= tokens.length * 2; outerLoopCounter++) {
-            let lineObj = util.getLineTokens(nextLineStartTokenIndex, tokens);
-
-            nextLineStartTokenIndex = lineObj.stopIndex + 1;
-            let lineTokens = lineObj.tokens;
-            let thisTabCount = tabCount;
-            let foundIndentorThisLine = false;
-            let foundNonWhitespaceThisLine = false;
-
-            for (let i = 0; i < lineTokens.length; i++) {
-                let token = lineTokens[i];
-                let previousNonWhitespaceToken = util.getPreviousNonWhitespaceToken(lineTokens, i);
-                let nextNonWhitespaceToken = util.getNextNonWhitespaceToken(lineTokens, i);
-
-                //if the previous token was `else` and this token is `if`, skip this token. (we used to have a single token for `elseif` but it got split out in an update of brighterscript)
-                if (previousNonWhitespaceToken?.kind === TokenKind.Else && token.kind === TokenKind.If) {
-                    continue;
-                }
-
-                //keep track of whether we found a non-Whitespace (or Newline) character
-                if (![TokenKind.Whitespace, TokenKind.Newline].includes(token.kind)) {
-                    foundNonWhitespaceThisLine = true;
-                }
-
-                if (
-                    //if this is an indentor token
-                    IndentSpacerTokenKinds.includes(token.kind) &&
-                    //is not being used as a key in an AA literal
-                    nextNonWhitespaceToken && nextNonWhitespaceToken.kind !== TokenKind.Colon
-                ) {
-                    //skip indent for 'function'|'sub' used as type (preceeded by `as` keyword)
-                    if (
-                        CallableKeywordTokenKinds.includes(token.kind) &&
-                        //the previous token will be Whitespace, so verify that previousPrevious is 'as'
-                        previousNonWhitespaceToken?.kind === TokenKind.As
-                    ) {
-                        continue;
-                    }
-
-                    //skip indent for single-line if statements
-                    let ifStatement = ifStatements.get(token);
-                    const endIfToken = this.getEndIfToken(ifStatement);
-                    if (
-                        ifStatement &&
-                        (
-                            //does not have an end if
-                            !endIfToken ||
-                            //end if is on same line as if
-                            ifStatement.tokens.if.range.end.line === endIfToken.range.end.line
-                        )
-                    ) {
-                        //if there's an `else`, skip past it since it'll cause de-indent otherwise
-                        if (ifStatement.tokens.else) {
-                            i = tokens.indexOf(ifStatement.tokens.else);
-                        }
-
-                        continue;
-                    }
-
-                    // check for specifically mentioned tokens to NOT indent
-                    const parentIndentTokenKind = getParentIndentTokenKind();
-                    if (parentIndentTokenKind && IgnoreIndentSpacerByParentTokenKind.get(parentIndentTokenKind)?.includes(token.kind)) {
-                        // This particular token should not be indented because it is listed in the ignore group for its parent
-                        continue;
-                    }
-
-                    tabCount++;
-                    foundIndentorThisLine = true;
-                    parentIndentTokenKinds.push(token.kind);
-
-
-                    //don't double indent if this is `[[...\n...]]` or `[{...\n...}]`
-                    if (
-                        //is open square
-                        token.kind === TokenKind.LeftSquareBracket &&
-                        //next is an open curly or square
-                        (nextNonWhitespaceToken.kind === TokenKind.LeftCurlyBrace || nextNonWhitespaceToken.kind === TokenKind.LeftSquareBracket) &&
-                        //both tokens are on the same line
-                        token.range.start.line === nextNonWhitespaceToken.range.start.line
-                    ) {
-                        //find the closer
-                        let closer = util.getClosingToken(tokens, tokens.indexOf(token), TokenKind.LeftSquareBracket, TokenKind.RightSquareBracket);
-                        let expectedClosingPreviousKind = nextNonWhitespaceToken.kind === TokenKind.LeftSquareBracket ? TokenKind.RightSquareBracket : TokenKind.RightCurlyBrace;
-                        let closingPrevious = closer && util.getPreviousNonWhitespaceToken(tokens, tokens.indexOf(closer), true);
-                        /* istanbul ignore else (because I can't figure out how to make this happen but I think it's still necessary) */
-                        if (closingPrevious && closingPrevious.kind === expectedClosingPreviousKind) {
-                            //skip the next token
-                            i++;
-                        }
-                    }
-                } else if (this.isOutdentToken(token, nextNonWhitespaceToken)) {
-                    //do not un-indent if this is a `next` or `endclass` token preceeded by a period
-                    if (
-                        [TokenKind.Next, TokenKind.EndClass, TokenKind.Namespace, TokenKind.EndNamespace].includes(token.kind) &&
-                        previousNonWhitespaceToken && previousNonWhitespaceToken.kind === TokenKind.Dot
-                    ) {
-                        continue;
-                    }
-
-                    tabCount--;
-                    if (foundIndentorThisLine === false) {
-                        thisTabCount--;
-                    }
-                    parentIndentTokenKinds.pop();
-
-                    //don't double un-indent if this is `[[...\n...]]` or `[{...\n...}]`
-                    if (
-                        //is closing curly or square
-                        (token.kind === TokenKind.RightCurlyBrace || token.kind === TokenKind.RightSquareBracket) &&
-                        //next is closing square
-                        nextNonWhitespaceToken && nextNonWhitespaceToken.kind === TokenKind.RightSquareBracket &&
-                        //both tokens are on the same line
-                        token.range.start.line === nextNonWhitespaceToken.range.start.line
-                    ) {
-                        let opener = this.getOpeningToken(
-                            tokens,
-                            tokens.indexOf(nextNonWhitespaceToken),
-                            TokenKind.LeftSquareBracket,
-                            TokenKind.RightSquareBracket
-                        );
-                        let openerNext = opener && util.getNextNonWhitespaceToken(tokens, tokens.indexOf(opener), true);
-                        if (openerNext && (openerNext.kind === TokenKind.LeftCurlyBrace || openerNext.kind === TokenKind.LeftSquareBracket)) {
-                            //skip the next token
-                            i += 1;
-                            continue;
-                        }
-                    }
-
-                    //this is an interum token
-                } else if (InterumSpacingTokenKinds.includes(token.kind)) {
-                    //these need outdented, but don't change the tabCount
-                    thisTabCount--;
-                }
-                //  else if (token.kind === TokenKind.return && foundIndentorThisLine) {
-                //     //a return statement on the same line as an indentor means we don't want to indent
-                //     tabCount--;
-                // }
-            }
-            //if the tab counts are less than zero, something is wrong. However, at least try to do formatting as best we can by resetting to 0
-            thisTabCount = thisTabCount < 0 ? 0 : thisTabCount;
-            tabCount = tabCount < 0 ? 0 : tabCount;
-
-            let leadingWhitespace: string;
-
-            if (options.indentStyle === 'spaces') {
-                let indentSpaceCount = options.indentSpaceCount
-                    ? options.indentSpaceCount
-                    : DEFAULT_INDENT_SPACE_COUNT;
-                let spaceCount = thisTabCount * indentSpaceCount;
-                leadingWhitespace = Array(spaceCount + 1).join(' ');
-            } else {
-                leadingWhitespace = Array(thisTabCount + 1).join('\t');
-            }
-            //create a Whitespace token if there isn't one
-            if (lineTokens[0] && lineTokens[0].kind !== TokenKind.Whitespace) {
-                lineTokens.unshift({
-                    startIndex: -1,
-                    kind: TokenKind.Whitespace,
-                    text: ''
-                } as TokenWithStartIndex);
-            }
-
-            //replace the Whitespace with the formatted Whitespace
-            lineTokens[0].text = leadingWhitespace;
-
-            //if this is a line filled only with Whitespace, throw out the Whitespace
-            if (foundNonWhitespaceThisLine === false) {
-                //only keep the traling Newline
-                lineTokens = [lineTokens.pop()!];
-            }
-
-            //add this list of tokens
-            outputTokens.push.apply(outputTokens, lineTokens);
-            let lastLineToken = lineTokens[lineTokens.length - 1];
-            //if we have found the end of file
+    /**
+     * Split the tokens by newline (including the newline or EOF as the last token in that array)
+     */
+    private splitTokensByLine(tokens: Token[]) {
+        const result: Array<Token[]> = [];
+        let line: Token[] = [];
+        for (let token of tokens) {
+            line.push(token);
             if (
-                lastLineToken && lastLineToken.kind === TokenKind.Eof
+                token.kind === TokenKind.Newline ||
+                token.kind === TokenKind.Eof
             ) {
-                break;
-            }
-            /* istanbul ignore next */
-            if (outerLoopCounter === tokens.length * 2) {
-                throw new Error('Something went terribly wrong');
+                result.push(line);
+                line = [];
             }
         }
-        return outputTokens;
+        return result;
     }
 
     /**

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -1,0 +1,55 @@
+import type { Token } from 'brighterscript';
+import { Lexer, TokenKind } from 'brighterscript';
+import { expect } from 'chai';
+
+export function expectTokens(actual: Token[], expected: Array<Partial<Token> | string>) {
+    //convert expected tokens into more usable format
+    expected = expected.map(x => {
+        if (typeof x === 'string') {
+            return {
+                text: x
+            };
+        } else {
+            return x;
+        }
+    });
+
+    //append an Eof token if we were not provided with one
+    if ((expected[expected.length - 1] as Token)?.kind !== TokenKind.Eof) {
+        expected.push({ kind: TokenKind.Eof });
+    }
+
+    const actualClones = [] as Token[];
+    for (let i = 0; i < actual.length; i++) {
+        const expectedDiagnostic = expected[i];
+        const actualDiagnostic = cloneObject(
+            actual[i],
+            expectedDiagnostic,
+            ['kind', 'text', 'range']
+        );
+        actualClones.push(actualDiagnostic as any);
+    }
+
+    expect(actualClones).to.eql(expected);
+}
+
+
+function cloneObject<TOriginal, TTemplate>(original: TOriginal, template: TTemplate, defaultKeys: Array<keyof TOriginal>) {
+    const clone = {} as Partial<TOriginal>;
+    let keys = Object.keys(template ?? {}) as Array<keyof TOriginal>;
+    //if there were no keys provided, use some sane defaults
+    keys = keys.length > 0 ? keys : defaultKeys;
+
+    //only compare the specified keys from actualDiagnostic
+    for (const key of keys) {
+        clone[key] = original[key];
+    }
+    return clone;
+}
+
+/**
+ * Shorthand for lexing a file and including whitespace
+ */
+export function lex(text: string): Token[] {
+    return Lexer.scan(text, { includeWhitespace: true }).tokens;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -89,7 +89,12 @@ export class Util {
         return text;
     }
 
-    public dedupeWhitespace(tokens: Token[]) {
+    /**
+     * Merge multiple side-by-side whitespace tokens into a single token containing all the whitespace.
+     * @param tokens the array of tokens to modify in-place
+     * @param leadingOnly stop processing if a non-whitespace token is encountered
+     */
+    public dedupeWhitespace(tokens: Token[], leadingOnly = false) {
         for (let i = 0; i < tokens.length; i++) {
             let currentToken = tokens[i];
             let nextToken = tokens[i + 1] ? tokens[i + 1] : { kind: undefined, text: '' };
@@ -98,6 +103,8 @@ export class Util {
                 tokens.splice(i + 1, 1);
                 //decrement the counter so we process this token again so it can absorb more Whitespace tokens
                 i--;
+            } else if (leadingOnly) {
+                return;
             }
         }
     }


### PR DESCRIPTION
Resolves #58 

- Splits the IndentFormatter `process` method into smaller, more understandable chunks. 
- process each line independently, and return a positive or negative offset which adjusts the outer overall indentation level. This simplifies the line logic because it no longer tracks the overall indentation level.
