### PR TITLE
Fix indent format issue related to optional chaining array access

### DIFF
--- a/src/Formatter.spec.ts
+++ b/src/Formatter.spec.ts
@@ -14,6 +14,16 @@ describe('Formatter', () => {
     });
 
     describe('formatIndent', () => {
+        it('formats with optional chaining operators', () => {
+            formatEqualTrim(`
+                sub setPoster()
+                    if m.arr?[1] <> invalid
+                        print true
+                    end if
+                end sub
+            `);
+        });
+
         it('formats simple if statement', () => {
             formatEqualTrim(`
                 if true then

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -86,6 +86,7 @@ export let IndentSpacerTokenKinds = [
     TokenKind.If,
     TokenKind.LeftCurlyBrace,
     TokenKind.LeftSquareBracket,
+    TokenKind.QuestionLeftSquare,
     TokenKind.While,
     TokenKind.HashIf,
     TokenKind.Class,


### PR DESCRIPTION
Fixes a bug in the indent formatter related to if statements and optional chaining operator with array brackets.

Fixes #70