### PR TITLE
Multi-line Function parameters

### DIFF
--- a/src/Formatter.spec.ts
+++ b/src/Formatter.spec.ts
@@ -2040,6 +2040,9 @@ end function`;
         expect(formatted).to.equal(expected);
     }
 
+    /**
+      * Same as formatEqual, but smart trims leading whitespace to the indent level of the first character found
+      */
     function formatEqualTrim(incoming: string, expected?: string, options?: FormattingOptions) {
         let sources = [
             incoming,

--- a/src/Formatter.spec.ts
+++ b/src/Formatter.spec.ts
@@ -252,6 +252,17 @@ describe('Formatter', () => {
            `);
         });
 
+        it('handles wrapped anon function over multiple lines in ternary properly', () => {
+            formatEqualTrim(`
+                sub main()
+                    a = true ? (sub()
+                        print hello
+                    end sub) : true
+                    print a
+                end sub
+           `);
+        });
+
         it('handles type statements with typed function types', () => {
             formatEqualTrim(`
                 type myFunc = function(a as string) as integer
@@ -1718,6 +1729,16 @@ end sub`;
     });
 
     describe('indentStyle', () => {
+        it('handles anon functions as function args', () => {
+            formatEqual(undent`
+                sub main()
+                    doSomething(sub()
+                        print 1
+                    end sub)
+                end sub
+            `);
+        });
+
         it('ignores methods with the name `catch` when contained within a function using a custom param type', () => {
             formatEqual(undent`
                 sub main()
@@ -1843,15 +1864,95 @@ end function`;
         });
     });
 
+    describe('multiline function parameters and calls', () => {
+        it('does not double indent [{...\\n...}]', () => {
+            formatEqualTrim(`
+                sub test()
+                    foo([{
+                        name: "bob"
+                    }])
+                end sub
+            `);
+        });
+
+        it('indents function parameters when already split across lines', () => {
+            formatEqualTrim(`
+                function foo(
+                param1 as string,
+                param2,
+                param3 as string
+                ) as string
+                end function
+            `, `
+                function foo(
+                    param1 as string,
+                    param2,
+                    param3 as string
+                ) as string
+                end function
+            `);
+        });
+
+        it('indents function parameters when already split across lines with function body', () => {
+            formatEqualTrim(`
+                function foo(
+                param1 as    string,
+                     param2  as       integer,
+                param3  as    string
+                )      as string
+                        print "hello"
+                return param1 + param2.toStr() + param3
+                end function
+            `, `
+                function foo(
+                    param1 as string,
+                    param2 as integer,
+                    param3 as string
+                ) as string
+                    print "hello"
+                    return param1 + param2.toStr() + param3
+                end function
+            `);
+        });
+
+        it('indents multiline function calls', () => {
+            formatEqualTrim(`
+                myPoster = createObject(
+                    "roSGNode",
+                    "Poster"
+                )
+            `);
+        });
+
+        it('fixes indents in multiline function calls', () => {
+            formatEqualTrim(`
+                myPoster = createObject(
+                         "roSGNode",
+                "Poster"
+                )
+            `, `
+                myPoster = createObject(
+                    "roSGNode",
+                    "Poster"
+                )
+            `);
+        });
+
+        it('does not modify single-line function declarations', () => {
+            formatEqual('function foo(param1 as string, param2, param3 as string) as string\nend function');
+        });
+
+        it('does not modify single-line function call', () => {
+            formatEqual('myPoster = createObject("roSGNode", "Poster")');
+        });
+    });
+
     function formatEqual(incoming: string, expected?: string, options?: FormattingOptions) {
         expected = expected ?? incoming;
         let formatted = formatter.format(incoming, options);
         expect(formatted).to.equal(expected);
     }
 
-    /**
-     * Same as formatEqual, but smart trims leading whitespace to the indent level of the first character found
-     */
     function formatEqualTrim(incoming: string, expected?: string, options?: FormattingOptions) {
         let sources = [
             incoming,
@@ -1860,22 +1961,22 @@ end function`;
         for (let i = 0; i < sources.length; i++) {
             let lines = sources[i].split('\n');
             //throw out leading newlines
-            while (lines[0].length === 0) {
+            while (lines.length > 0 && lines[0].length === 0) {
                 lines.splice(0, 1);
             }
             let trimStartIndex = null as number | null;
             for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
                 //if we don't have a starting trim count, compute it
-                if (!trimStartIndex) {
+                if (trimStartIndex === null && lines[lineIndex].trim().length > 0) {
                     trimStartIndex = lines[lineIndex].length - lines[lineIndex].trim().length;
                 }
 
-                if (lines[lineIndex].length > 0) {
+                if (lines[lineIndex].length > 0 && trimStartIndex !== null) {
                     lines[lineIndex] = lines[lineIndex].substring(trimStartIndex);
                 }
             }
             //trim trailing newlines
-            while (lines[lines.length - 1].length === 0) {
+            while (lines.length > 0 && lines[lines.length - 1].length === 0) {
                 lines.splice(lines.length - 1);
             }
             sources[i] = lines.join('\n');

--- a/src/Formatter.spec.ts
+++ b/src/Formatter.spec.ts
@@ -1875,6 +1875,14 @@ end function`;
             `);
         });
 
+        it('does not double indent when sub passed to function', () => {
+            formatEqualTrim(`
+                callSomeFuncWithSubParam(sub()
+                    print "hello"
+                end sub)
+            `);
+        });
+
         it('indents function parameters when already split across lines', () => {
             formatEqualTrim(`
                 function foo(
@@ -1890,6 +1898,24 @@ end function`;
                     param3 as string
                 ) as string
                 end function
+            `);
+        });
+
+        it('indents sub parameters when already split across lines', () => {
+            formatEqualTrim(`
+                sub foo(
+                param1 as string,
+                param2,
+                param3 as string
+                ) as string
+                end sub
+            `, `
+                sub foo(
+                    param1 as string,
+                    param2,
+                    param3 as string
+                ) as string
+                end sub
             `);
         });
 
@@ -1984,6 +2010,29 @@ end function`;
                     end function
                 }
                 
+            `);
+        });
+
+        it('allows indents of grouping expressions', () => {
+            formatEqualTrim(`
+                a = b * (
+                    3 - 2
+                )
+            `);
+        });
+
+        it('allows grouping expressions in function calls', () => {
+            formatEqualTrim(`
+                someFunc(
+                    (4 + 7) * 2
+                )
+            `);
+            formatEqualTrim(`
+                someFunc(
+                    (
+                        4 + 7
+                    ) * 2
+                )
             `);
         });
 

--- a/src/Formatter.spec.ts
+++ b/src/Formatter.spec.ts
@@ -1945,6 +1945,93 @@ end function`;
         it('does not modify single-line function call', () => {
             formatEqual('myPoster = createObject("roSGNode", "Poster")');
         });
+
+        it('indents multiline callfunc calls', () => {
+            formatEqualTrim(`
+                myPoster = someNode@.someCallFunc(
+                    1,
+                    2,
+                    { data: "bob" }
+                )
+            `);
+        });
+
+        it('fixes indents in multiline callfunc calls', () => {
+            formatEqualTrim(`
+                myPoster = someNode@.someCallFunc(
+                         1,
+                2,
+                   {data: "bob"}
+                )
+            `, `
+                myPoster = someNode@.someCallFunc(
+                    1,
+                    2,
+                    { data: "bob" }
+                )
+            `);
+        });
+
+        it('indents in multiline function declarations in aa literals', () => {
+            formatEqualTrim(`
+                {
+                    func: function(
+                        param1 as function
+                    ) as string
+                        return param1(
+                            "hello"
+                        )
+                    end function
+                }
+                
+            `);
+        });
+
+        it('indents in multiline function calls with aa literals', () => {
+            formatEqualTrim(`
+                someFunc(
+                    1,
+                    { data: "bob" },
+                    {
+                        name: "multiLineAA",
+                        value: 22
+                    },
+                    {
+                        func: sub()
+                            print "hello"
+                        end sub,
+                        func2: function(
+                            param1 as function
+                        ) as string
+                            return param1(
+                                "hello"
+                            )
+                        end function
+                    }
+                )
+            `);
+        });
+
+        it('indents function calls with multiple args per line ', () => {
+            formatEqualTrim(`
+                someFunc(1, { data: "bob" }, {
+                        name: "multiLineAA",
+                        value: 22
+                    }, "hello", {
+                        func: sub()
+                            print "hello"
+                        end sub,
+                        func2: function(
+                            param1 as function
+                        ) as string
+                            return param1(
+                                "hello"
+                            )
+                        end function
+                    }
+                )
+            `);
+        });
     });
 
     function formatEqual(incoming: string, expected?: string, options?: FormattingOptions) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -87,6 +87,7 @@ export let IndentSpacerTokenKinds = [
     TokenKind.LeftCurlyBrace,
     TokenKind.LeftSquareBracket,
     TokenKind.QuestionLeftSquare,
+    TokenKind.LeftParen,
     TokenKind.While,
     TokenKind.HashIf,
     TokenKind.Class,
@@ -115,6 +116,7 @@ export let IgnoreIndentSpacerByParentTokenKind = new Map<TokenKind, TokenKind[]>
 export let OutdentSpacerTokenKinds = [
     TokenKind.RightCurlyBrace,
     TokenKind.RightSquareBracket,
+    TokenKind.RightParen,
     TokenKind.EndFunction,
     TokenKind.EndIf,
     TokenKind.EndSub,
@@ -216,3 +218,16 @@ export const ConditionalCompileTokenKinds = [
 export const CompositeKeywordStartingWords = ['end', 'exit', 'else', '#end', '#else'];
 
 export const AllowedClassIdentifierKinds = [TokenKind.Identifier, ...AllowedLocalIdentifiers];
+
+export const IndentGroupingTokenKinds = [
+    TokenKind.LeftCurlyBrace,
+    TokenKind.LeftSquareBracket,
+    TokenKind.QuestionLeftSquare,
+    TokenKind.LeftParen
+];
+
+export const OutdentGroupingTokenKinds = [
+    TokenKind.RightCurlyBrace,
+    TokenKind.RightSquareBracket,
+    TokenKind.RightParen
+];

--- a/src/formatters/IndentFormatter.spec.ts
+++ b/src/formatters/IndentFormatter.spec.ts
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
 import { expectTokens, lex } from '../testHelpers.spec';
 import { IndentFormatter } from './IndentFormatter';
+import type { Token } from 'brighterscript';
+import { TokenKind } from 'brighterscript';
 
 describe('IndentFormatter', () => {
     let formatter: IndentFormatter;
@@ -75,6 +77,44 @@ describe('IndentFormatter', () => {
                 formatter['trimWhitespaceOnlyLines'](lex(` speak()`)),
                 [' ', 'speak', '(', ')']
             );
+        });
+    });
+
+    describe('getMatchingOpeningTokens', () => {
+        it('returns null for tokens with no expected opening tokens', () => {
+            const tokes = lex(`some random tokens`);
+            expect(
+                formatter['getMatchingOpeningTokens'](tokes, [tokes[0]], 0)
+            ).to.eql([]);
+        });
+    });
+
+    describe('getMatchingClosingTokens', () => {
+        it('returns null for tokens with no expected closing tokens', () => {
+            const tokes = lex(`some random tokens`);
+            expect(
+                formatter['getMatchingClosingTokens'](tokes, [tokes[0]], 0)
+            ).to.eql([]);
+        });
+    });
+
+    describe('getExpectedOpeningTokens', () => {
+        it('returns correct possible opening tokens', () => {
+            expect(
+                formatter['getExpectedOpeningTokens']({ kind: TokenKind.RightParen } as Token)
+            ).to.eql([TokenKind.LeftParen, TokenKind.QuestionLeftParen]);
+
+            expect(
+                formatter['getExpectedOpeningTokens']({ kind: TokenKind.RightSquareBracket } as Token)
+            ).to.eql([TokenKind.LeftSquareBracket, TokenKind.QuestionLeftSquare]);
+
+            expect(
+                formatter['getExpectedOpeningTokens']({ kind: TokenKind.EndSub } as Token)
+            ).to.eql([TokenKind.Sub]);
+
+            expect(
+                formatter['getExpectedOpeningTokens']({ kind: TokenKind.Identifier } as Token)
+            ).to.eql([]);
         });
     });
 });

--- a/src/formatters/IndentFormatter.ts
+++ b/src/formatters/IndentFormatter.ts
@@ -1,7 +1,7 @@
 import type { Token, Parser, IfStatement } from 'brighterscript';
 import { isIfStatement, createVisitor, TokenKind, WalkMode } from 'brighterscript';
 import type { TokenWithStartIndex } from '../constants';
-import { OutdentSpacerTokenKinds, IndentSpacerTokenKinds, CallableKeywordTokenKinds, IgnoreIndentSpacerByParentTokenKind, InterumSpacingTokenKinds, DEFAULT_INDENT_SPACE_COUNT } from '../constants';
+import { OutdentSpacerTokenKinds, IndentSpacerTokenKinds, CallableKeywordTokenKinds, IgnoreIndentSpacerByParentTokenKind, InterumSpacingTokenKinds, DEFAULT_INDENT_SPACE_COUNT, IndentGroupingTokenKinds, OutdentGroupingTokenKinds } from '../constants';
 import type { FormattingOptions } from '../FormattingOptions';
 import { util } from '../util';
 
@@ -21,6 +21,7 @@ export class IndentFormatter {
 
         let parentIndentTokenKinds: TokenKind[] = [];
 
+        this.multiLineFuncDeclarationOpeners = [];
         //the list of output tokens
         let result: Token[] = [];
 
@@ -45,6 +46,8 @@ export class IndentFormatter {
         }
         return result;
     }
+
+    private multiLineFuncDeclarationOpeners: Token[] = [];
 
     private processLine(
         lineTokens: Token[],
@@ -84,7 +87,7 @@ export class IndentFormatter {
                 //if this is an indentor token
                 IndentSpacerTokenKinds.includes(token.kind) &&
                 //is not being used as a key in an AA literal
-                nextNonWhitespaceToken && nextNonWhitespaceToken.kind !== TokenKind.Colon
+                (nextNonWhitespaceToken && nextNonWhitespaceToken.kind !== TokenKind.Colon)
             ) {
                 //skip indent for 'function'|'sub' used as type (preceeded by `as` keyword)
                 if (
@@ -152,29 +155,23 @@ export class IndentFormatter {
                     continue;
                 }
 
-                nextLineOffset++;
-                foundIndentorThisLine = true;
+                const isOpenFunctionDeclarationParamList = this.isStartOfOpenFunctionDeclarationParamList(lineTokens, i);
+
+                if (isOpenFunctionDeclarationParamList) {
+                    this.multiLineFuncDeclarationOpeners.push(token);
+                } else {
+                    nextLineOffset++;
+                    foundIndentorThisLine = true;
+                }
                 parentIndentTokenKinds.push(token.kind);
 
                 //don't double indent if this is `[[...\n...]]` or `[{...\n...}]`
-                if (
-                    //is open square
-                    token.kind === TokenKind.LeftSquareBracket &&
-                    //next is an open curly or square
-                    (nextNonWhitespaceToken.kind === TokenKind.LeftCurlyBrace || nextNonWhitespaceToken.kind === TokenKind.LeftSquareBracket) &&
-                    //both tokens are on the same line
-                    token.range.start.line === nextNonWhitespaceToken.range.start.line
-                ) {
-                    //find the closer
-                    let closer = util.getClosingToken(tokens, tokens.indexOf(token), TokenKind.LeftSquareBracket, TokenKind.RightSquareBracket);
-                    let expectedClosingPreviousKind = nextNonWhitespaceToken.kind === TokenKind.LeftSquareBracket ? TokenKind.RightSquareBracket : TokenKind.RightCurlyBrace;
-                    let closingPrevious = closer && util.getPreviousNonWhitespaceToken(tokens, tokens.indexOf(closer), true);
-                    /* istanbul ignore else (because I can't figure out how to make this happen but I think it's still necessary) */
-                    if (closingPrevious && closingPrevious.kind === expectedClosingPreviousKind) {
-                        //skip the next token
-                        i++;
-                    }
+                const numUnmatchedOpenTokens = this.getNumberOfUnmatchedOpenTokensOnOneLine(tokens, tokens.indexOf(token));
+                if (numUnmatchedOpenTokens > 1) {
+                    //skip the next token for each unmatched open token on the same line
+                    i += (numUnmatchedOpenTokens - 1);
                 }
+
             } else if (this.isOutdentToken(token, nextNonWhitespaceToken)) {
                 //do not un-indent if this is a `next` or `endclass` token preceeded by a period
                 if (
@@ -190,27 +187,27 @@ export class IndentFormatter {
                 }
                 parentIndentTokenKinds.pop();
 
-                //don't double un-indent if this is `[[...\n...]]` or `[{...\n...}]`
-                if (
-                    //is closing curly or square
-                    (token.kind === TokenKind.RightCurlyBrace || token.kind === TokenKind.RightSquareBracket) &&
-                    //next is closing square
-                    nextNonWhitespaceToken && nextNonWhitespaceToken.kind === TokenKind.RightSquareBracket &&
-                    //both tokens are on the same line
-                    token.range.start.line === nextNonWhitespaceToken.range.start.line
-                ) {
+                if (token.kind === TokenKind.RightParen) {
                     let opener = this.getOpeningToken(
                         tokens,
-                        tokens.indexOf(nextNonWhitespaceToken),
-                        TokenKind.LeftSquareBracket,
-                        TokenKind.RightSquareBracket
+                        tokens.indexOf(token),
+                        [TokenKind.LeftParen],
+                        TokenKind.RightParen
                     );
-                    let openerNext = opener && util.getNextNonWhitespaceToken(tokens, tokens.indexOf(opener), true);
-                    if (openerNext && (openerNext.kind === TokenKind.LeftCurlyBrace || openerNext.kind === TokenKind.LeftSquareBracket)) {
-                        //skip the next token
-                        i += 1;
-                        continue;
+                    if (this.multiLineFuncDeclarationOpeners.includes(opener!)) {
+                        // finish function declaration at same level as function opener
+                        currentLineOffset--;
+                        // indent function body
+                        nextLineOffset++;
+                        this.multiLineFuncDeclarationOpeners = this.multiLineFuncDeclarationOpeners.filter(x => x !== opener);
                     }
+                }
+
+                //don't double un-indent if this is `[[...\n...]]` or `[{...\n...}]`
+                const numUnmatchedCloseTokens = this.getNumberOfUnmatchedCloseTokensOnOneLine(tokens, tokens.indexOf(token));
+                if (numUnmatchedCloseTokens > 1) {
+                    //skip the next token for each unmatched open token on the same line
+                    i += (numUnmatchedCloseTokens - 1);
                 }
 
                 //this is an interum token
@@ -218,15 +215,166 @@ export class IndentFormatter {
                 //these need outdented, but don't change the tabCount
                 currentLineOffset--;
             }
-            //  else if (token.kind === TokenKind.return && foundIndentorThisLine) {
-            //     //a return statement on the same line as an indentor means we don't want to indent
-            //     tabCount--;
-            // }
         }
         return {
             currentLineOffset: currentLineOffset,
             nextLineOffset: nextLineOffset
         };
+    }
+
+    private getConsecutiveTokensByTypeOnOneLine(tokens: Token[], currentIndex: number, targetTokenKinds: TokenKind[]): Token[] {
+        const currentToken = tokens[currentIndex];
+
+        const isApplicableTokenKind = targetTokenKinds.includes(currentToken.kind);
+        if (!isApplicableTokenKind) {
+            return [];
+        }
+
+        let nextNonWhitespaceTokenIndex = util.getNextNonWhitespaceTokenIndex(tokens, currentIndex);
+        let targetTokens = [currentToken];
+
+        while (typeof nextNonWhitespaceTokenIndex === 'number') {
+
+            const nextNonWhitespaceToken = tokens[nextNonWhitespaceTokenIndex];
+
+            if (!nextNonWhitespaceToken) {
+                break;
+            }
+            const isNextTokenAnOpenToken = targetTokenKinds.includes(nextNonWhitespaceToken.kind);
+
+            if (isNextTokenAnOpenToken && currentToken.range.start.line === nextNonWhitespaceToken.range.start.line) {
+                targetTokens.push(nextNonWhitespaceToken);
+                nextNonWhitespaceTokenIndex = util.getNextNonWhitespaceTokenIndex(tokens, nextNonWhitespaceTokenIndex);
+            } else {
+                break;
+            }
+        }
+        return targetTokens;
+    }
+
+    private getConsecutiveOpenTokensOnOneLine(tokens: Token[], currentIndex: number): Token[] {
+        return this.getConsecutiveTokensByTypeOnOneLine(tokens, currentIndex, [...IndentGroupingTokenKinds, ...CallableKeywordTokenKinds]);
+    }
+
+    private getConsecutiveCloseTokensOnOneLine(tokens: Token[], currentIndex: number): Token[] {
+        return this.getConsecutiveTokensByTypeOnOneLine(tokens, currentIndex, [...OutdentGroupingTokenKinds, TokenKind.EndSub, TokenKind.EndFunction]);
+    }
+
+    private getMatchingClosingTokens(allTokens: Token[], openTokens: Token[], currentIndex: number): (Token | null)[] {
+        const closingTokens: (Token | null)[] = [];
+        for (let openToken of openTokens) {
+            const expectedClosingTokenKind = this.getExpectedClosingToken(openToken);
+            if (!expectedClosingTokenKind) {
+                continue;
+            }
+            const closingToken = util.getClosingToken(allTokens, allTokens.indexOf(openToken), openToken.kind, expectedClosingTokenKind);
+            if (closingToken) {
+                closingTokens.push(closingToken);
+            } else {
+                closingTokens.push(null);
+            }
+        }
+        return closingTokens;
+    }
+
+    private getMatchingOpeningTokens(allTokens: Token[], closeTokens: Token[], currentIndex: number): (Token | null)[] {
+        const closingTokens: (Token | null)[] = [];
+        for (let closeToken of closeTokens) {
+            const expectedClosingTokenKinds = this.getExpectedOpeningTokens(closeToken);
+            if (expectedClosingTokenKinds.length < 1) {
+                continue;
+            }
+            const openingToken = this.getOpeningToken(allTokens, allTokens.indexOf(closeToken), expectedClosingTokenKinds, closeToken.kind);
+            if (openingToken) {
+                closingTokens.push(openingToken);
+            } else {
+                closingTokens.push(null);
+            }
+        }
+        return closingTokens;
+    }
+
+    private getNumberOfUnmatchedOpenTokensOnOneLine(tokens: Token[], currentIndex: number): number {
+        const openTokens = this.getConsecutiveOpenTokensOnOneLine(tokens, currentIndex);
+        const closingTokens = this.getMatchingClosingTokens(tokens, openTokens, currentIndex);
+        const closeTokensOnSameLine = closingTokens.filter(token => token !== null && token.range.start.line === tokens[currentIndex].range.start.line);
+        return openTokens.length - closeTokensOnSameLine.length;
+    }
+
+    private getNumberOfUnmatchedCloseTokensOnOneLine(tokens: Token[], currentIndex: number): number {
+        const closeTokens = this.getConsecutiveCloseTokensOnOneLine(tokens, currentIndex);
+        const openingTokens = this.getMatchingOpeningTokens(tokens, closeTokens, currentIndex);
+        const closeTokensOnSameLine = openingTokens.filter(token => token !== null && token.range.start.line === tokens[currentIndex].range.start.line);
+        return closeTokens.length - closeTokensOnSameLine.length;
+    }
+
+    /**
+     * Gets an array of all possible closing token kinds for a given opening token
+     */
+    private getExpectedClosingToken(openToken: Token): TokenKind | undefined {
+        if (openToken.kind === TokenKind.LeftCurlyBrace) {
+            return TokenKind.RightCurlyBrace;
+        } else if (openToken.kind === TokenKind.LeftSquareBracket) {
+            return TokenKind.RightSquareBracket;
+        } else if (openToken.kind === TokenKind.QuestionLeftSquare) {
+            return TokenKind.RightSquareBracket;
+        } else if (openToken.kind === TokenKind.LeftParen) {
+            return TokenKind.RightParen;
+        } else if (openToken.kind === TokenKind.Sub) {
+            return TokenKind.EndSub;
+        } else if (openToken.kind === TokenKind.Function) {
+            return TokenKind.EndFunction;
+        }
+    }
+
+    /**
+     * Gets an array of all possible opening token kinds for a given closing token
+     */
+    private getExpectedOpeningTokens(closeToken: Token): TokenKind[] {
+        if (closeToken.kind === TokenKind.RightCurlyBrace) {
+            return [TokenKind.RightCurlyBrace];
+        } else if (closeToken.kind === TokenKind.RightSquareBracket) {
+            return [TokenKind.LeftSquareBracket, TokenKind.QuestionLeftSquare];
+        } else if (closeToken.kind === TokenKind.RightParen) {
+            return [TokenKind.LeftParen, TokenKind.QuestionLeftParen];
+        } else if (closeToken.kind === TokenKind.Sub) {
+            return [TokenKind.EndSub];
+        } else if (closeToken.kind === TokenKind.Function) {
+            return [TokenKind.EndFunction];
+        }
+        return [];
+    }
+
+    private isStartOfOpenFunctionDeclarationParamList(lineTokens: Token[], currentIndex: number): boolean {
+        const currentToken = lineTokens[currentIndex];
+        if (currentToken.kind !== TokenKind.LeftParen) {
+            return false;
+        }
+        const previousNonWhitespaceToken = util.getPreviousNonWhitespaceToken(lineTokens, currentIndex);
+        if (!previousNonWhitespaceToken) {
+            return false;
+        }
+        let isFunctionDeclarationParamList = false;
+        if (CallableKeywordTokenKinds.includes(previousNonWhitespaceToken.kind)) {
+            // this is "function(" or "sub("
+            isFunctionDeclarationParamList = true;
+        } else if (previousNonWhitespaceToken.kind === TokenKind.Identifier) {
+            const previousPreviousNonWhitespaceToken = util.getPreviousNonWhitespaceToken(lineTokens, lineTokens.indexOf(previousNonWhitespaceToken), true);
+            if (!previousPreviousNonWhitespaceToken) {
+                return false;
+            }
+            if (CallableKeywordTokenKinds.includes(previousPreviousNonWhitespaceToken.kind)) {
+                // this is "function someName(" or "sub someName("
+                isFunctionDeclarationParamList = true;
+            }
+        }
+        if (isFunctionDeclarationParamList) {
+            let closingToken = this.getMatchingClosingTokens(lineTokens, [lineTokens[currentIndex]], currentIndex)[0];
+            if (!closingToken) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -333,11 +481,11 @@ export class IndentFormatter {
     /**
      * Given a kind like `}` or `]`, walk backwards until we find its match
      */
-    public getOpeningToken(tokens: Token[], currentIndex: number, openKind: TokenKind, closeKind: TokenKind) {
+    public getOpeningToken(tokens: Token[], currentIndex: number, openKinds: TokenKind[], closeKind: TokenKind) {
         let openCount = 0;
         for (let i = currentIndex; i >= 0; i--) {
             let token = tokens[i];
-            if (token.kind === openKind) {
+            if (openKinds.includes(token.kind)) {
                 openCount++;
             } else if (token.kind === closeKind) {
                 openCount--;
@@ -353,7 +501,7 @@ export class IndentFormatter {
      */
     public isOutdentToken(token: Token, nextNonWhitespaceToken?: Token) {
         //this is a temporary fix for broken indentation for brighterscript ternary operations.
-        const isSymbol = [TokenKind.RightCurlyBrace, TokenKind.RightSquareBracket].includes(token.kind);
+        const isSymbol = [TokenKind.RightCurlyBrace, TokenKind.RightSquareBracket, TokenKind.RightParen].includes(token.kind);
         if (
             //this is an outdentor token
             OutdentSpacerTokenKinds.includes(token.kind) &&

--- a/src/formatters/IndentFormatter.ts
+++ b/src/formatters/IndentFormatter.ts
@@ -166,7 +166,13 @@ export class IndentFormatter {
                 parentIndentTokenKinds.push(token.kind);
 
                 //don't double indent if this is `[[...\n...]]` or `[{...\n...}]`
-                const numUnmatchedOpenTokens = this.getNumberOfUnmatchedOpenTokensOnOneLine(tokens, tokens.indexOf(token));
+                let numUnmatchedOpenTokens = this.getNumberOfUnmatchedOpenTokensOnOneLine(tokens, tokens.indexOf(token));
+                if (numUnmatchedOpenTokens > 0 && CallableKeywordTokenKinds.includes(token.kind) &&
+                    nextNonWhitespaceToken?.kind === TokenKind.LeftParen &&
+                    this.isStartOfOpenFunctionDeclarationParamList(lineTokens, i + 1)) {
+                    // this is a function declaration "function(", do not skip the next token
+                    numUnmatchedOpenTokens--;
+                }
                 if (numUnmatchedOpenTokens > 1) {
                     //skip the next token for each unmatched open token on the same line
                     i += (numUnmatchedOpenTokens - 1);
@@ -195,8 +201,6 @@ export class IndentFormatter {
                         TokenKind.RightParen
                     );
                     if (this.multiLineFuncDeclarationOpeners.includes(opener!)) {
-                        // finish function declaration at same level as function opener
-                        currentLineOffset--;
                         // indent function body
                         nextLineOffset++;
                         this.multiLineFuncDeclarationOpeners = this.multiLineFuncDeclarationOpeners.filter(x => x !== opener);
@@ -206,7 +210,7 @@ export class IndentFormatter {
                 //don't double un-indent if this is `[[...\n...]]` or `[{...\n...}]`
                 const numUnmatchedCloseTokens = this.getNumberOfUnmatchedCloseTokensOnOneLine(tokens, tokens.indexOf(token));
                 if (numUnmatchedCloseTokens > 1) {
-                    //skip the next token for each unmatched open token on the same line
+                    //skip the next token for each unmatched close token on the same line
                     i += (numUnmatchedCloseTokens - 1);
                 }
 

--- a/src/formatters/IndentFormatter.ts
+++ b/src/formatters/IndentFormatter.ts
@@ -168,7 +168,6 @@ export class IndentFormatter {
                 //don't double indent if this is `[[...\n...]]` or `[{...\n...}]`
                 let numUnmatchedOpenTokens = this.getNumberOfUnmatchedOpenTokensOnOneLine(tokens, tokens.indexOf(token));
                 if (numUnmatchedOpenTokens > 0 && CallableKeywordTokenKinds.includes(token.kind) &&
-                    nextNonWhitespaceToken?.kind === TokenKind.LeftParen &&
                     this.isStartOfOpenFunctionDeclarationParamList(lineTokens, i + 1)) {
                     // this is a function declaration "function(", do not skip the next token
                     numUnmatchedOpenTokens--;
@@ -238,12 +237,8 @@ export class IndentFormatter {
         let targetTokens = [currentToken];
 
         while (typeof nextNonWhitespaceTokenIndex === 'number') {
-
             const nextNonWhitespaceToken = tokens[nextNonWhitespaceTokenIndex];
 
-            if (!nextNonWhitespaceToken) {
-                break;
-            }
             const isNextTokenAnOpenToken = targetTokenKinds.includes(nextNonWhitespaceToken.kind);
 
             if (isNextTokenAnOpenToken && currentToken.range.start.line === nextNonWhitespaceToken.range.start.line) {
@@ -282,7 +277,7 @@ export class IndentFormatter {
     }
 
     private getMatchingOpeningTokens(allTokens: Token[], closeTokens: Token[], currentIndex: number): (Token | null)[] {
-        const closingTokens: (Token | null)[] = [];
+        const openingTokens: (Token | null)[] = [];
         for (let closeToken of closeTokens) {
             const expectedClosingTokenKinds = this.getExpectedOpeningTokens(closeToken);
             if (expectedClosingTokenKinds.length < 1) {
@@ -290,12 +285,12 @@ export class IndentFormatter {
             }
             const openingToken = this.getOpeningToken(allTokens, allTokens.indexOf(closeToken), expectedClosingTokenKinds, closeToken.kind);
             if (openingToken) {
-                closingTokens.push(openingToken);
+                openingTokens.push(openingToken);
             } else {
-                closingTokens.push(null);
+                openingTokens.push(null);
             }
         }
-        return closingTokens;
+        return openingTokens;
     }
 
     private getNumberOfUnmatchedOpenTokensOnOneLine(tokens: Token[], currentIndex: number): number {
@@ -336,15 +331,15 @@ export class IndentFormatter {
      */
     private getExpectedOpeningTokens(closeToken: Token): TokenKind[] {
         if (closeToken.kind === TokenKind.RightCurlyBrace) {
-            return [TokenKind.RightCurlyBrace];
+            return [TokenKind.LeftCurlyBrace];
         } else if (closeToken.kind === TokenKind.RightSquareBracket) {
             return [TokenKind.LeftSquareBracket, TokenKind.QuestionLeftSquare];
         } else if (closeToken.kind === TokenKind.RightParen) {
             return [TokenKind.LeftParen, TokenKind.QuestionLeftParen];
-        } else if (closeToken.kind === TokenKind.Sub) {
-            return [TokenKind.EndSub];
-        } else if (closeToken.kind === TokenKind.Function) {
-            return [TokenKind.EndFunction];
+        } else if (closeToken.kind === TokenKind.EndSub) {
+            return [TokenKind.Sub];
+        } else if (closeToken.kind === TokenKind.EndFunction) {
+            return [TokenKind.Function];
         }
         return [];
     }

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -36,4 +36,48 @@ describe('util', () => {
             expect(tokens).to.be.lengthOf(1);
         });
     });
+
+    describe('getNextNonWhitespaceTokenIndex', () => {
+        it('returns undefined when index is out of bounds', () => {
+            expect(util.getNextNonWhitespaceTokenIndex([], -1)).to.be.undefined;
+        });
+
+        it('returns undefined when stopAtNewLine is true and found a newline', () => {
+            const tokens = [{
+                kind: TokenKind.Identifier,
+                text: 'hello',
+                startIndex: 0
+            }, {
+                kind: TokenKind.Whitespace,
+                text: ' ',
+                startIndex: 0
+            }, {
+                kind: TokenKind.Newline,
+                text: '\n',
+                startIndex: 0
+            }];
+            expect(util.getNextNonWhitespaceTokenIndex(tokens as any, 0, true)).to.be.undefined;
+        });
+
+        it('returns the index of the next non-whitespace token', () => {
+            const tokens = [{
+                kind: TokenKind.Identifier,
+                text: 'hello',
+                startIndex: 0
+            }, {
+                kind: TokenKind.Whitespace,
+                text: ' ',
+                startIndex: 0
+            }, {
+                kind: TokenKind.Identifier,
+                text: 'world',
+                startIndex: 0
+            }, {
+                kind: TokenKind.Newline,
+                text: '\n',
+                startIndex: 0
+            }];
+            expect(util.getNextNonWhitespaceTokenIndex(tokens as any, 0, true)).to.equal(2);
+        });
+    });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -51,13 +51,24 @@ export class Util {
         if (index < 0) {
             return;
         }
+        const foundIndex = this.getNextNonWhitespaceTokenIndex(tokens, index, stopAtNewLine);
+        if (foundIndex === undefined) {
+            return;
+        }
+        return tokens[foundIndex];
+    }
+
+    public getNextNonWhitespaceTokenIndex(tokens: Token[], index: number, stopAtNewLine = false) {
+        if (index < 0) {
+            return;
+        }
         for (index += 1; index < tokens.length; index++) {
             let token = tokens[index];
             if (stopAtNewLine && token && token.kind === TokenKind.Newline) {
                 return;
             }
             if (token && token.kind !== TokenKind.Whitespace) {
-                return token;
+                return index;
             }
         }
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,11 @@
         "strict": true,
         "strictNullChecks": true,
         "noUnusedLocals": true,
-        "skipLibCheck": true
+        "skipLibCheck": true,
+        "types": [
+            "mocha",
+            "chai"
+        ]
     },
     "include": [
         "src/**/*.ts"


### PR DESCRIPTION
Formats multi-line function parameters.

- Allows multi-line function declaration
- Allows multi-line function calls
- Refactors indent/outdent logic 


eg:

Function declaration:
```
function foo(
    param1 as string,
    param2 as integer,
    param3 as string
) as string
    print "hello"
    return param1 + param2.toStr() + param3
end function
```

Function call:
```
someFunc(
    1,
    { data: "bob" },
    {
        name: "multiLineAA",
        value: 22
    },
    {
        func: sub()
            print "hello"
        end sub,
        func2: function(
            param1 as function
        ) as string
            return param1(
                "hello"
            )
        end function
    }
)
```