### PR TITLE
Fix multi-line indentation regression from 1.7.28 (#143)

### DIFF
--- a/src/Formatter.spec.ts
+++ b/src/Formatter.spec.ts
@@ -2064,21 +2064,169 @@ end function`;
         it('indents function calls with multiple args per line ', () => {
             formatEqualTrim(`
                 someFunc(1, { data: "bob" }, {
-                        name: "multiLineAA",
-                        value: 22
-                    }, "hello", {
-                        func: sub()
-                            print "hello"
-                        end sub,
-                        func2: function(
-                            param1 as function
-                        ) as string
-                            return param1(
-                                "hello"
-                            )
-                        end function
-                    }
+                    name: "multiLineAA",
+                    value: 22
+                }, "hello", {
+                    func: sub()
+                        print "hello"
+                    end sub,
+                    func2: function(
+                        param1 as function
+                    ) as string
+                        return param1(
+                            "hello"
+                        )
+                    end function
+                }
                 )
+            `);
+        });
+
+        it('indents nested multi-line function calls one level per call', () => {
+            formatEqualTrim(`
+                sub test()
+                    outer(
+                        inner(
+                            value
+                        )
+                    )
+                end sub
+            `);
+        });
+
+        it('does not double indent three groups that open adjacently on one line', () => {
+            formatEqualTrim(`
+                sub test()
+                    foo([{
+                        name: "bob"
+                    }])
+                end sub
+            `);
+        });
+
+        it('indents a multi-line optional-index expression', () => {
+            formatEqualTrim(`
+                sub test()
+                    value = data?[
+                        0
+                    ]
+                end sub
+            `);
+        });
+
+        it('indents a multi-line optional-call expression', () => {
+            formatEqualTrim(`
+                sub test()
+                    value = foo?(
+                        1
+                    )
+                end sub
+            `);
+        });
+
+        it('does not double indent a multi-line array of arrays opened on one line', () => {
+            formatEqualTrim(`
+                sub test()
+                    grid = [[
+                        1
+                    ]]
+                end sub
+            `);
+        });
+
+        it('does not double indent an object arg following a `as function` type annotation', () => {
+            formatEqualTrim(`
+                sub test()
+                    register(handler as function, {
+                        name: "bob"
+                    })
+                end sub
+            `);
+        });
+
+        it('does not double indent an object arg following an inline sub argument', () => {
+            formatEqualTrim(`
+                sub test()
+                    register(sub() : end sub, {
+                        name: "bob"
+                    })
+                end sub
+            `);
+        });
+
+        it('does not double indent an object literal as the last call arg closed with `})` (issue #143)', () => {
+            formatEqualTrim(`
+                sub test()
+                    result = doThing(value, {
+                        name: "bob"
+                    })
+                end sub
+            `);
+        });
+
+        it('does not double indent an array literal as the last call arg closed with `])` (issue #143)', () => {
+            formatEqualTrim(`
+                sub test()
+                    result = doThing(value, [
+                        1
+                        2
+                    ])
+                end sub
+            `);
+        });
+
+        it('does not double indent a function passed as the last call arg closed with `end function)` (issue #143)', () => {
+            formatEqualTrim(`
+                sub test()
+                    SetNavigation(a, b, c, function()
+                        ScrollUp()
+                    end function)
+                    SetNavigation(d, e, f)
+                end sub
+            `);
+        });
+
+        it('does not double indent a sub passed as the last call arg closed with `end sub)` (issue #143)', () => {
+            formatEqualTrim(`
+                sub test()
+                    SetNavigation(a, b, c, sub()
+                        ScrollUp()
+                    end sub)
+                    SetNavigation(d, e, f)
+                end sub
+            `);
+        });
+
+        it('does not drift indentation when an object opens on its own line and closes with `})` (issue #143)', () => {
+            formatEqualTrim(`
+                function getImage(showId as string)
+                    result = api.GetEpisodes(showId,
+                        {
+                            seasonId: seasonId,
+                            limit: 5
+                        })
+                    return result
+                end function
+            `);
+        });
+
+        it('does not drift indentation after `})` for the rest of the function (issue #143)', () => {
+            formatEqualTrim(`
+                function ExecuteJob() as void
+                    if isInnertubeProfile
+                        subscriptionStatus = GetSubscriptionStatusForChannel(ucid, {
+                            cancellation: cancellation
+                            accessToken: authToken.token
+                        })
+
+                        if subscriptionStatus.error <> invalid
+                            return
+                        end if
+                        channelView.isSubscribed = subscriptionStatus.isSubscribed
+                    else
+                        service = createService(invidiousNode)
+                    end if
+                end function
             `);
         });
     });

--- a/src/Formatter.spec.ts
+++ b/src/Formatter.spec.ts
@@ -1765,6 +1765,21 @@ end sub`;
             `);
         });
 
+        it('does not de-indent on a typecast inside chained anonymous functions (#82)', () => {
+            formatEqualTrim(`
+                sub test()
+                    if true
+                        if true
+                            promises.chain(media as dynamic).then(sub()
+                                print 1
+                            end sub).catch(sub()
+                            end sub)
+                        end if
+                    end if
+                end sub
+            `);
+        });
+
         describe('conditional block', () => {
             it('correctly fixes the indentation', () => {
                 let expected = `#if isDebug\n    doSomething()\n#end if`;
@@ -2090,6 +2105,34 @@ end function`;
                             value
                         )
                     )
+                end sub
+            `);
+        });
+
+        it('indents a multi-line call with mixed args, a nested call, and a trailing comment (#131)', () => {
+            formatEqualTrim(`
+                sub main()
+                    callOtherFunction(
+                        "param1",
+                        "param2",
+                        [1, 2, 3],
+                        { allowAA: true },
+                        nestedFunctionCall(
+                            "nestedParam"
+                        ),
+                        "commentsOnSameLine" ' this may require a Brightscript parser update?
+                    )
+                end sub
+            `);
+        });
+
+        it('indents a multi-line function declaration with a default object-literal param (#131)', () => {
+            formatEqualTrim(`
+                sub multiLineFunctionDeclaration(
+                    param1 as string,
+                    param2 as boolean,
+                    param3 = { test: "AA" } as roAssociativeArray
+                )
                 end sub
             `);
         });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -88,6 +88,7 @@ export let IndentSpacerTokenKinds = [
     TokenKind.LeftSquareBracket,
     TokenKind.QuestionLeftSquare,
     TokenKind.LeftParen,
+    TokenKind.QuestionLeftParen,
     TokenKind.While,
     TokenKind.HashIf,
     TokenKind.Class,
@@ -223,7 +224,8 @@ export const IndentGroupingTokenKinds = [
     TokenKind.LeftCurlyBrace,
     TokenKind.LeftSquareBracket,
     TokenKind.QuestionLeftSquare,
-    TokenKind.LeftParen
+    TokenKind.LeftParen,
+    TokenKind.QuestionLeftParen
 ];
 
 export const OutdentGroupingTokenKinds = [

--- a/src/formatters/IndentFormatter.spec.ts
+++ b/src/formatters/IndentFormatter.spec.ts
@@ -1,8 +1,6 @@
 import { expect } from 'chai';
 import { expectTokens, lex } from '../testHelpers.spec';
 import { IndentFormatter } from './IndentFormatter';
-import type { Token } from 'brighterscript';
-import { TokenKind } from 'brighterscript';
 
 describe('IndentFormatter', () => {
     let formatter: IndentFormatter;
@@ -80,15 +78,6 @@ describe('IndentFormatter', () => {
         });
     });
 
-    describe('getMatchingOpeningTokens', () => {
-        it('returns null for tokens with no expected opening tokens', () => {
-            const tokes = lex(`some random tokens`);
-            expect(
-                formatter['getMatchingOpeningTokens'](tokes, [tokes[0]], 0)
-            ).to.eql([]);
-        });
-    });
-
     describe('getMatchingClosingTokens', () => {
         it('returns null for tokens with no expected closing tokens', () => {
             const tokes = lex(`some random tokens`);
@@ -98,23 +87,4 @@ describe('IndentFormatter', () => {
         });
     });
 
-    describe('getExpectedOpeningTokens', () => {
-        it('returns correct possible opening tokens', () => {
-            expect(
-                formatter['getExpectedOpeningTokens']({ kind: TokenKind.RightParen } as Token)
-            ).to.eql([TokenKind.LeftParen, TokenKind.QuestionLeftParen]);
-
-            expect(
-                formatter['getExpectedOpeningTokens']({ kind: TokenKind.RightSquareBracket } as Token)
-            ).to.eql([TokenKind.LeftSquareBracket, TokenKind.QuestionLeftSquare]);
-
-            expect(
-                formatter['getExpectedOpeningTokens']({ kind: TokenKind.EndSub } as Token)
-            ).to.eql([TokenKind.Sub]);
-
-            expect(
-                formatter['getExpectedOpeningTokens']({ kind: TokenKind.Identifier } as Token)
-            ).to.eql([]);
-        });
-    });
 });

--- a/src/formatters/IndentFormatter.ts
+++ b/src/formatters/IndentFormatter.ts
@@ -22,6 +22,7 @@ export class IndentFormatter {
         let parentIndentTokenKinds: TokenKind[] = [];
 
         this.multiLineFuncDeclarationOpeners = [];
+        this.collapsedGroupClosers = new Set<Token>();
         //the list of output tokens
         let result: Token[] = [];
 
@@ -49,6 +50,12 @@ export class IndentFormatter {
 
     private multiLineFuncDeclarationOpeners: Token[] = [];
 
+    /**
+     * Closers belonging to bracket groups that were collapsed on the open side (because more than one group opened on
+     * the same line). The close side skips the un-indent for these so opens and closes stay balanced.
+     */
+    private collapsedGroupClosers = new Set<Token>();
+
     private processLine(
         lineTokens: Token[],
         tokens: Token[],
@@ -63,6 +70,7 @@ export class IndentFormatter {
         let currentLineOffset = 0;
         let nextLineOffset = 0;
         let foundIndentorThisLine = false;
+        let outdentedThisLine = false;
         let firstNonWhitespaceToken: Token | null = null;
 
         for (let i = 0; i < lineTokens.length; i++) {
@@ -157,6 +165,18 @@ export class IndentFormatter {
 
                 const isOpenFunctionDeclarationParamList = this.isStartOfOpenFunctionDeclarationParamList(lineTokens, i);
 
+                //collapse multiple bracket groups that open on the same line into a single indent level: only the first
+                //unclosed opener on a line adds a level; a later opener whose enclosing group opened on the same line is
+                //collapsed into it (e.g. the `{` in `foo(arg, {` ... `})`, or `[{` ... `}]`). We record the enclosing
+                //group's closer so the close side skips its matching un-indent, keeping opens and closes balanced.
+                if (!isOpenFunctionDeclarationParamList) {
+                    const enclosingCloser = this.getCollapsibleEnclosingCloser(tokens, tokens.indexOf(token));
+                    if (enclosingCloser) {
+                        this.collapsedGroupClosers.add(enclosingCloser);
+                        continue;
+                    }
+                }
+
                 if (isOpenFunctionDeclarationParamList) {
                     this.multiLineFuncDeclarationOpeners.push(token);
                 } else {
@@ -164,18 +184,6 @@ export class IndentFormatter {
                     foundIndentorThisLine = true;
                 }
                 parentIndentTokenKinds.push(token.kind);
-
-                //don't double indent if this is `[[...\n...]]` or `[{...\n...}]`
-                let numUnmatchedOpenTokens = this.getNumberOfUnmatchedOpenTokensOnOneLine(tokens, tokens.indexOf(token));
-                if (numUnmatchedOpenTokens > 0 && CallableKeywordTokenKinds.includes(token.kind) &&
-                    this.isStartOfOpenFunctionDeclarationParamList(lineTokens, i + 1)) {
-                    // this is a function declaration "function(", do not skip the next token
-                    numUnmatchedOpenTokens--;
-                }
-                if (numUnmatchedOpenTokens > 1) {
-                    //skip the next token for each unmatched open token on the same line
-                    i += (numUnmatchedOpenTokens - 1);
-                }
 
             } else if (this.isOutdentToken(token, nextNonWhitespaceToken)) {
                 //do not un-indent if this is a `next` or `endclass` token preceeded by a period
@@ -186,9 +194,19 @@ export class IndentFormatter {
                     continue;
                 }
 
+                //skip the un-indent for a closer whose group was collapsed on the open side (more than one group opened
+                //on the same line). The matching opener didn't add a level, so this closer must not remove one.
+                if (this.collapsedGroupClosers.has(token)) {
+                    this.collapsedGroupClosers.delete(token);
+                    continue;
+                }
+
                 nextLineOffset--;
-                if (foundIndentorThisLine === false) {
+                //only the first leading closer dedents the current line, aligning it with that closer's opener (e.g.
+                //the `}` in `})` aligns the line with its `{`); later closers on the line only affect the next line
+                if (foundIndentorThisLine === false && !outdentedThisLine) {
                     currentLineOffset--;
+                    outdentedThisLine = true;
                 }
                 parentIndentTokenKinds.pop();
 
@@ -206,13 +224,6 @@ export class IndentFormatter {
                     }
                 }
 
-                //don't double un-indent if this is `[[...\n...]]` or `[{...\n...}]`
-                const numUnmatchedCloseTokens = this.getNumberOfUnmatchedCloseTokensOnOneLine(tokens, tokens.indexOf(token));
-                if (numUnmatchedCloseTokens > 1) {
-                    //skip the next token for each unmatched close token on the same line
-                    i += (numUnmatchedCloseTokens - 1);
-                }
-
                 //this is an interum token
             } else if (InterumSpacingTokenKinds.includes(token.kind)) {
                 //these need outdented, but don't change the tabCount
@@ -223,40 +234,6 @@ export class IndentFormatter {
             currentLineOffset: currentLineOffset,
             nextLineOffset: nextLineOffset
         };
-    }
-
-    private getConsecutiveTokensByTypeOnOneLine(tokens: Token[], currentIndex: number, targetTokenKinds: TokenKind[]): Token[] {
-        const currentToken = tokens[currentIndex];
-
-        const isApplicableTokenKind = targetTokenKinds.includes(currentToken.kind);
-        if (!isApplicableTokenKind) {
-            return [];
-        }
-
-        let nextNonWhitespaceTokenIndex = util.getNextNonWhitespaceTokenIndex(tokens, currentIndex);
-        let targetTokens = [currentToken];
-
-        while (typeof nextNonWhitespaceTokenIndex === 'number') {
-            const nextNonWhitespaceToken = tokens[nextNonWhitespaceTokenIndex];
-
-            const isNextTokenAnOpenToken = targetTokenKinds.includes(nextNonWhitespaceToken.kind);
-
-            if (isNextTokenAnOpenToken && currentToken.range.start.line === nextNonWhitespaceToken.range.start.line) {
-                targetTokens.push(nextNonWhitespaceToken);
-                nextNonWhitespaceTokenIndex = util.getNextNonWhitespaceTokenIndex(tokens, nextNonWhitespaceTokenIndex);
-            } else {
-                break;
-            }
-        }
-        return targetTokens;
-    }
-
-    private getConsecutiveOpenTokensOnOneLine(tokens: Token[], currentIndex: number): Token[] {
-        return this.getConsecutiveTokensByTypeOnOneLine(tokens, currentIndex, [...IndentGroupingTokenKinds, ...CallableKeywordTokenKinds]);
-    }
-
-    private getConsecutiveCloseTokensOnOneLine(tokens: Token[], currentIndex: number): Token[] {
-        return this.getConsecutiveTokensByTypeOnOneLine(tokens, currentIndex, [...OutdentGroupingTokenKinds, TokenKind.EndSub, TokenKind.EndFunction]);
     }
 
     private getMatchingClosingTokens(allTokens: Token[], openTokens: Token[], currentIndex: number): (Token | null)[] {
@@ -276,35 +253,62 @@ export class IndentFormatter {
         return closingTokens;
     }
 
-    private getMatchingOpeningTokens(allTokens: Token[], closeTokens: Token[], currentIndex: number): (Token | null)[] {
-        const openingTokens: (Token | null)[] = [];
-        for (let closeToken of closeTokens) {
-            const expectedClosingTokenKinds = this.getExpectedOpeningTokens(closeToken);
-            if (expectedClosingTokenKinds.length < 1) {
+    /**
+     * If the open token at `currentIndex` is a multi-line group nested directly inside another group that opened on the
+     * same line, return that enclosing group's closing token (so the open side can collapse them into a single indent
+     * level and the close side can skip the matching un-indent). Returns undefined when this token should indent on its
+     * own (it is the first unclosed group to open on its line, or it opens and closes on the same line).
+     */
+    private getCollapsibleEnclosingCloser(tokens: Token[], currentIndex: number): Token | null | undefined {
+        const openToken = tokens[currentIndex];
+        const closingToken = this.getMatchingClosingTokens(tokens, [openToken], currentIndex)[0];
+        //a group that opens and closes on the same line never adds an indent level, so it can't be collapsed
+        if (!closingToken || closingToken.range.start.line === openToken.range.start.line) {
+            return undefined;
+        }
+        const enclosingOpenToken = this.getImmediateEnclosingOpenerOnSameLine(tokens, currentIndex);
+        if (!enclosingOpenToken) {
+            return undefined;
+        }
+        //null when the enclosing group has no closer (unbalanced source); the caller treats that as "don't collapse"
+        return this.getMatchingClosingTokens(tokens, [enclosingOpenToken], tokens.indexOf(enclosingOpenToken))[0];
+    }
+
+    /**
+     * Walk backward from `currentIndex` to find the opener that directly encloses it, but only if that opener is on the
+     * same line. Balanced groups encountered along the way are skipped via depth tracking. Returns undefined if the
+     * start of the line is reached first (i.e. there is no enclosing opener on this line).
+     */
+    private getImmediateEnclosingOpenerOnSameLine(tokens: Token[], currentIndex: number): Token | undefined {
+        const openerKinds = [...IndentGroupingTokenKinds, ...CallableKeywordTokenKinds];
+        const closerKinds = [...OutdentGroupingTokenKinds, TokenKind.EndSub, TokenKind.EndFunction];
+        let depth = 0;
+        for (let i = currentIndex - 1; i >= 0; i--) {
+            const candidate = tokens[i];
+            if (candidate.kind === TokenKind.Newline) {
+                return undefined;
+            }
+            if (candidate.kind === TokenKind.Whitespace) {
                 continue;
             }
-            const openingToken = this.getOpeningToken(allTokens, allTokens.indexOf(closeToken), expectedClosingTokenKinds, closeToken.kind);
-            if (openingToken) {
-                openingTokens.push(openingToken);
-            } else {
-                openingTokens.push(null);
+            //`function`/`sub` used as a type (e.g. `as function`) is not a block opener, so don't let it match
+            if (CallableKeywordTokenKinds.includes(candidate.kind)) {
+                //the optional chain only short-circuits at the start of the file, which the scan never reaches here
+                /* istanbul ignore next */
+                if (util.getPreviousNonWhitespaceToken(tokens, i)?.kind === TokenKind.As) {
+                    continue;
+                }
+            }
+            if (closerKinds.includes(candidate.kind)) {
+                depth++;
+            } else if (openerKinds.includes(candidate.kind)) {
+                if (depth === 0) {
+                    return candidate;
+                }
+                depth--;
             }
         }
-        return openingTokens;
-    }
-
-    private getNumberOfUnmatchedOpenTokensOnOneLine(tokens: Token[], currentIndex: number): number {
-        const openTokens = this.getConsecutiveOpenTokensOnOneLine(tokens, currentIndex);
-        const closingTokens = this.getMatchingClosingTokens(tokens, openTokens, currentIndex);
-        const closeTokensOnSameLine = closingTokens.filter(token => token !== null && token.range.start.line === tokens[currentIndex].range.start.line);
-        return openTokens.length - closeTokensOnSameLine.length;
-    }
-
-    private getNumberOfUnmatchedCloseTokensOnOneLine(tokens: Token[], currentIndex: number): number {
-        const closeTokens = this.getConsecutiveCloseTokensOnOneLine(tokens, currentIndex);
-        const openingTokens = this.getMatchingOpeningTokens(tokens, closeTokens, currentIndex);
-        const closeTokensOnSameLine = openingTokens.filter(token => token !== null && token.range.start.line === tokens[currentIndex].range.start.line);
-        return closeTokens.length - closeTokensOnSameLine.length;
+        return undefined;
     }
 
     /**
@@ -319,29 +323,13 @@ export class IndentFormatter {
             return TokenKind.RightSquareBracket;
         } else if (openToken.kind === TokenKind.LeftParen) {
             return TokenKind.RightParen;
+        } else if (openToken.kind === TokenKind.QuestionLeftParen) {
+            return TokenKind.RightParen;
         } else if (openToken.kind === TokenKind.Sub) {
             return TokenKind.EndSub;
         } else if (openToken.kind === TokenKind.Function) {
             return TokenKind.EndFunction;
         }
-    }
-
-    /**
-     * Gets an array of all possible opening token kinds for a given closing token
-     */
-    private getExpectedOpeningTokens(closeToken: Token): TokenKind[] {
-        if (closeToken.kind === TokenKind.RightCurlyBrace) {
-            return [TokenKind.LeftCurlyBrace];
-        } else if (closeToken.kind === TokenKind.RightSquareBracket) {
-            return [TokenKind.LeftSquareBracket, TokenKind.QuestionLeftSquare];
-        } else if (closeToken.kind === TokenKind.RightParen) {
-            return [TokenKind.LeftParen, TokenKind.QuestionLeftParen];
-        } else if (closeToken.kind === TokenKind.EndSub) {
-            return [TokenKind.Sub];
-        } else if (closeToken.kind === TokenKind.EndFunction) {
-            return [TokenKind.Function];
-        }
-        return [];
     }
 
     private isStartOfOpenFunctionDeclarationParamList(lineTokens: Token[], currentIndex: number): boolean {


### PR DESCRIPTION
Fixes #143.

Also adds regression coverage confirming #131 (multi-line calls and declarations) and #82 (typecast inside chained anonymous functions) — both were implemented/fixed in 1.7.28 (#140) but had no explicit tests for the reported scenarios and were never closed:

Closes #131
Closes #82

## Problem
1.7.28 (#140, multi-line function parameters) made `(` an indent token but left the bookkeeping asymmetric. When more than one bracket group opens on the same line — e.g. `foo(arg, {` … `})` — the open side counted `+2` while the matching `})` collapsed to `-1`, leaving a permanent `+1` drift that pushed every following line (including `end function`) one level deeper.

## Fix
Replace the old "collapse adjacent opens / collapse consecutive closes" scheme with a single rule applied symmetrically to both sides:

- Only the **first unclosed group** opened on a line adds an indent level. Later groups opened on the same line collapse into it; the close side records and skips their matching un-indents so opens and closes stay balanced.
- A closing line now aligns with the **opener of its first closer** (`}` in `})` lines up with its `{`), instead of dedenting once per closer.

Also adds `QuestionLeftParen` (`?(`) as an indent token. `)` was already an outdent token, so multi-line optional calls (`foo?(` … `)`) drifted the other way.

Handles same-line (`foo(arg, {`), adjacent (`foo([{`), and different-line (`foo(arg,`⏎`{`) groups, plus `?[`/`?(`, callfunc, tabs, and deep nesting.

Verified idempotent on playlet (the repo from the issue), jellyfin-roku, and jellyrock.