### PR TITLE
Fix de-indent of multi-line call continuation lines ending with a closing paren

### DIFF
--- a/src/Formatter.spec.ts
+++ b/src/Formatter.spec.ts
@@ -2409,6 +2409,26 @@ end function`;
             `);
         });
 
+        it('indents a continuation line ending with the closing paren', () => {
+            formatEqualTrim(`
+                sub test()
+                    m.assertEqual(result, expected,
+                        "message text")
+                end sub
+            `);
+        });
+
+        it('indents consecutive multi-line calls whose continuations end with a template literal closing paren', () => {
+            formatEqualTrim(`
+                sub test(input, expected)
+                    m.assertTrue(Type(result) = "roBoolean" or Type(result) = "Boolean",
+                        \`toBoolean('\${input}') should return boolean type but got \${Type(result)}\`)
+                    m.assertEqual(result, expected,
+                        \`toBoolean('\${input}') should return \${expected} but got \${result}\`)
+                end sub
+            `);
+        });
+
         it('does not double indent a multi-line array of arrays opened on one line', () => {
             formatEqualTrim(`
                 sub test()

--- a/src/formatters/IndentFormatter.ts
+++ b/src/formatters/IndentFormatter.ts
@@ -69,8 +69,6 @@ export class IndentFormatter {
 
         let currentLineOffset = 0;
         let nextLineOffset = 0;
-        let foundIndentorThisLine = false;
-        let outdentedThisLine = false;
         let firstNonWhitespaceToken: Token | null = null;
 
         for (let i = 0; i < lineTokens.length; i++) {
@@ -181,7 +179,6 @@ export class IndentFormatter {
                     this.multiLineFuncDeclarationOpeners.push(token);
                 } else {
                     nextLineOffset++;
-                    foundIndentorThisLine = true;
                 }
                 parentIndentTokenKinds.push(token.kind);
 
@@ -211,11 +208,11 @@ export class IndentFormatter {
                 }
 
                 nextLineOffset--;
-                //only the first leading closer dedents the current line, aligning it with that closer's opener (e.g.
-                //the `}` in `})` aligns the line with its `{`); later closers on the line only affect the next line
-                if (foundIndentorThisLine === false && !outdentedThisLine) {
+                //only dedent the current line when it *starts* with a closer, aligning the line with that closer's
+                //opener (e.g. the `}` in a leading `})`). A closer at the end of a content/continuation line must not
+                //pull the line back - e.g. the trailing `)` in `m.assertEqual(a,` ⏎ `` `msg`) `` keeps the +1 indent.
+                if (token === firstNonWhitespaceToken) {
                     currentLineOffset--;
-                    outdentedThisLine = true;
                 }
                 parentIndentTokenKinds.pop();
 


### PR DESCRIPTION
Follow-up to #145. Reported via downstream formatting on a real codebase: a multi-line call whose continuation line ends with the closing `)` was being de-indented back to the call's level.

```brightscript
m.assertEqual(result, expected,
    `msg`)          ' continuation got pulled back to the m.assertEqual level
```

## Cause
The current line was dedented whenever no indentor preceded the closer on that line (`foundIndentorThisLine === false`). That condition is also true for a closer at the *end* of a content/continuation line, so the line got pulled back. It only appeared to work for some lines: e.g. a template interpolation containing parens (`${Type(result)}`) flips the flag, so the next call's continuation — whose interpolations have no parens (`${expected}`) — broke instead. The underlying bug affects any multi-line call ending in `)`, template or not.

## Fix
Dedent the current line only when the closer is the **first non-whitespace token** on the line (a line that actually starts with a closer). This also subsumes the earlier "align a leading `})` with its opener" behavior, so the now-redundant `foundIndentorThisLine` / `outdentedThisLine` flags are removed.

Added regression tests (both fail on master, pass with the fix). Verified idempotent on playlet, jellyfin-roku, and jellyrock.